### PR TITLE
Simplified SFTP hierarchy and refacotred sftp part

### DIFF
--- a/tasks/set_acl_results.yml
+++ b/tasks/set_acl_results.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create each contained result directory
   file:
-         path: "/var/results/{{ result_type }}/{{ item }}"
+         path: "/var/results/{{ item }}/{{ result_type }}"
          state: directory
          owner: root
          group: root
@@ -11,7 +11,7 @@
 
 - name: Give proper ACL permissions
   acl:
-         path: "/var/results/{{ result_type }}/{{ item }}"
+         path: "/var/results/{{ item }}/{{ result_type }}"
          entity: "{{ item }}"
          etype: group
          permissions: rx
@@ -22,7 +22,7 @@
 
 - name: Give proper ACL permissions
   acl:
-         path: "/var/results/{{ result_type }}/{{ item }}"
+         path: "/var/results/{{ item }}/{{ result_type }}"
          entity: "{{ item }}"
          etype: group
          permissions: rx
@@ -33,7 +33,7 @@
 
 - name: Give proper ACL permissions
   acl:
-         path: "/var/results/{{ result_type }}/{{ item.cgroup }}"
+         path: "/var/results/{{ item.cgroup }}/{{ result_type }}"
          entity: "jslave-{{ item.cgroup }}"
          etype: group
          permissions: wx
@@ -44,7 +44,7 @@
 
 - name: Give proper ACL permissions
   acl:
-         path: "/var/results/{{ result_type }}/{{ item.cgroup }}"
+         path: "/var/results/{{ item.cgroup }}/{{ result_type }}"
          entity: "jslave-{{ item.cgroup }}"
          etype: group
          permissions: w

--- a/tasks/setup_sftp.yml
+++ b/tasks/setup_sftp.yml
@@ -54,7 +54,7 @@
   with_items:
          - "{{ users }}"
 
-- name: Create repositories for results (2655 <=> 0755 + (g+s)
+- name: Create repositories for results
   file:
          path: /var/results
          state: directory

--- a/tasks/setup_sftp.yml
+++ b/tasks/setup_sftp.yml
@@ -54,15 +54,13 @@
   with_items:
          - "{{ users }}"
 
-- name: Create repositories for results
+- name: Create repositories for results (2655 <=> 0755 + (g+s)
   file:
          path: /var/results
          state: directory
          owner: root
          group: root
-
-- name: Set GID bit on the results dir
-  shell: "chmod g+s /var/results"
+         mode: "2655"
 
 - name: Create repositories for results and toolchains
   file:
@@ -70,17 +68,9 @@
          state: directory
          owner: root
          group: root
+         mode: "2655"
   with_items:
-    - benchmark
-    - openhpc
-    - toolchains
-    - conffiles
-
-- name: Set GID bit on the results and toolchain dir
-  shell: "chmod g+s /var/results/{{ item }}"
-  with_items:
-    - benchmark
-    - openhpc
+    - "{{ vendors_list }}"
     - toolchains
     - conffiles
 

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -124,10 +124,10 @@ Match Group jslave-{{ item }}
         ForceCommand internal-sftp -d /var/results -u 0557
 
 Match Group {{ item }}
-	ChrootDirectory /var/results/
+	ChrootDirectory /var/results/{{ item }}
         AllowTCPForwarding no
         X11Forwarding no
-        ForceCommand internal-sftp -d /var/results/qualcomm
+        ForceCommand internal-sftp -d /var/results/{{ item }}
 {% endfor %}
 
 # Example of overriding settings on a per-user basis


### PR DESCRIPTION
Instead of /var/results/"typeofresult"/"vendor"/"results"
We now have /var/results/"vendor"/"typeofresult"/"results"

The chroot for vendor users is thus /var/results/"vendor"