### PR TITLE
Refactored Jenkins slave's ssh key template manipulation

### DIFF
--- a/jenkins.yml
+++ b/jenkins.yml
@@ -1,19 +1,13 @@
 ---
 - hosts: jenkins
   remote_user: root
-  vars:
-          jslave_list:
-                  - "d03ohpc"
-                  - "d03bench"
-                  - "d05ohpc"
-                  - "d05bench"
-                  - "tx2ohpc"
-                  - "tx2bench"
-                  - "qdcohpc"
-                  - "qdcbench"
-                  - "xecutor"
-
   tasks:
+          - include_vars:
+                  file: ./vars/jslave_list.yml
+
+          - include_vars:
+                  file: ./vars/jslave_to_sftp.yml
+
           - name: Check that Jenkins master has an SSH key
             stat:
                 path: "/var/lib/jenkins/.ssh/id_rsa.pub"

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -51,7 +51,7 @@
                     state: present
                     key: "{{ ssh_keyscan_result.stdout }}"
 
-          - name: Create jenkins_slave group to keep them from unionizing
+          - name: Create jenkins_slave group
             group:
                     name: jenkins_slave
                     state: present
@@ -152,7 +152,7 @@
                         }
                         Jenkins.getInstanceOrNull().setNodes(Jenkins.getInstanceOrNull().getNodes())
 
-          # The above groovy line is needed to force Jenkins to reaload the slaves... neat huh ? :S
+          # The above groovy line is needed to force Jenkins to reaload the slaves
                         
           - name: Check for python deps
             command: dpkg-query -l python3 python3-pip python-requests python-future

--- a/tasks/create_slaves.yml
+++ b/tasks/create_slaves.yml
@@ -15,38 +15,26 @@
           mode: 0700
   with_list: "{{ jslave_list }}"
 
-- name: Copy the ssh_keys from the remote
+- name: Give the master's ssh key to the slaves
   copy:
       src: "{{ key_path }}"
       dest: "/home/{{ item }}/.ssh/id_rsa"
       remote_src: yes
   with_list: "{{ jslave_list }}"
 
-- name: Fetch the ssh_keys from the remote
-  fetch:
-      src: "{{ key_path }}.pub"
-      dest: "./templates/{{ item }}.sshkey"
-      flat: yes
-  with_list: "{{ jslave_list }}"
+- name: Slurping up the master's private key into a variable
+  slurp:
+    src: "{{ key_path }}"
+  register: master_private_key
 
 - name: Putting the keys into the template for the fileserver
   template:
-    src: "templates/jslaves-openhpc.yml.j2"
-    dest: "/tmp/jslaves-openhpc.yml"
-
-- name: Putting the keys into the template for the fileserver
-  template:
-    src: "templates/jslaves-benchmark.yml.j2"
-    dest: "/tmp/jslaves-benchmark.yml"
-    
-- name: Get the template back
-  fetch:
-    src: "/tmp/{{ item }}"
-    dest: "./vars/{{ item }}.secret"
-    flat: yes
+    src: "templates/{{ item }}.j2"
+    dest: "vars/{{ item }}"
   with_items:
         - jslaves-benchmark.yml
         - jslaves-openhpc.yml
+  delegate_to: localhost
 
 - name: Add Master Jenkins' ssh key to the slaves authorized list
   authorized_key:

--- a/templates/jslaves-benchmark.yml.j2
+++ b/templates/jslaves-benchmark.yml.j2
@@ -9,6 +9,6 @@ jslaves_benchmark:
 {% elif item is match(".*tx.*") %}
       cgroup: cavium
 {% endif %}
-      ssh_key: {% include '%s.sshkey' % item %}
+      ssh_key: {{ master_private_key['content'] | b64decode }}
 
 {% endfor %}

--- a/templates/jslaves-benchmark.yml.j2
+++ b/templates/jslaves-benchmark.yml.j2
@@ -2,13 +2,10 @@
 jslaves_benchmark:
 {% for item in jslave_list|select("match", ".*bench.*") %}
     - name: {{ item }}
-{% if item is match(".*qdc.*") %}
-      cgroup: qualcomm
-{% elif item is match(".*d0.*") %}
-      cgroup: huawei
-{% elif item is match(".*tx.*") %}
-      cgroup: cavium
+{% for r in sftp_groups %}
+{% if item is match(r.regex) %}
+      cgroup: {{ r.group }}
 {% endif %}
+{% endfor %}
       ssh_key: {{ master_private_key['content'] | b64decode }}
-
 {% endfor %}

--- a/templates/jslaves-openhpc.yml.j2
+++ b/templates/jslaves-openhpc.yml.j2
@@ -2,13 +2,10 @@
 jslaves_openhpc:
 {% for item in jslave_list|select("match", ".*ohpc.*") %}
     - name: {{ item }}
-{% if item is match(".*qdc.*") %}
-      cgroup: qualcomm
-{% elif item is match(".*d0.*") %}
-      cgroup: huawei
-{% elif item is match(".*tx.*") %}
-      cgroup: cavium
+{% for r in sftp_groups %}
+{% if item is match(r.regex) %}
+      cgroup: {{ r.group }}
 {% endif %}
+{% endfor %}
       ssh_key: {{ master_private_key['content'] | b64decode }}
-
 {% endfor %}

--- a/templates/jslaves-openhpc.yml.j2
+++ b/templates/jslaves-openhpc.yml.j2
@@ -9,6 +9,6 @@ jslaves_openhpc:
 {% elif item is match(".*tx.*") %}
       cgroup: cavium
 {% endif %}
-      ssh_key: {% include '%s.sshkey' % item %}
+      ssh_key: {{ master_private_key['content'] | b64decode }}
 
 {% endfor %}

--- a/vars/jslave_list.yml
+++ b/vars/jslave_list.yml
@@ -1,0 +1,11 @@
+---
+jslave_list:
+- "d03ohpc"
+- "d03bench"
+- "d05ohpc"
+- "d05bench"
+- "tx2ohpc"
+- "tx2bench"
+- "qdcohpc"
+- "qdcbench"
+- "xecutor"

--- a/vars/jslave_to_sftp.yml
+++ b/vars/jslave_to_sftp.yml
@@ -1,0 +1,8 @@
+---
+sftp_groups:
+- regex: ".*qdc.*"
+  group: qualcomm
+- regex: ".*d0.*"
+  group: huawei
+- regex: ".*tx.*"
+  group: cavium 


### PR DESCRIPTION
This refactor makes use of the fact that the jslaves all share the same ssh key.
Templates are still separated since one could have a configuration where the machine models for openhpc and benchmarks are different.

Note that the templates need to be rewritten by users to correspond to the groups (qdc, d03) that their machines are part of, and those here are adapted to our configuration and serve as an example.