### PR TITLE
Added lmod_mpi_default package name override

### DIFF
--- a/files/ohpc_install.yml
+++ b/files/ohpc_install.yml
@@ -109,6 +109,7 @@
                                 # Enable components options
                                 enable_beegfs_client=False
                                 enable_mpi_defaults=True
+                                ohpc_lmod_mpi_default="lmod-defaults-gnu8-openmpi3-ohpc"
                                 enable_mpi_opa=False
                                 enable_clustershell=True
                                 enable_ipmisol=False
@@ -161,7 +162,8 @@
                         cnode_eth_internal: ${eth_provision}
                         force_service: ${force_service}
                         enable_beegfs_client: ${enable_beegfs_client}
-                        enable_mpi_defaults: ${enable_mpi_defaults} 
+                        enable_mpi_defaults: ${enable_mpi_defaults}
+                        ohpc_lmod_mpi_default: ${ohpc_lmod_mpi_default}
                         enable_mpi_opa: ${enable_mpi_opa}
                         enable_clustershell: ${enable_clustershell}
                         enable_ipmisol: ${enable_ipmisol}


### PR DESCRIPTION
Following the recent update (1.3.6) of OpenHPC, the gnu7-openmpi3 combination does not exist anymore, and one has to use gnu8-openmpi3.
The default before this patch is gnu7-openmpi, which has brought problems with the test suite before.