### PR TITLE
Add TX2 to test suite job and fix D05 nodenames

### DIFF
--- a/files/ohpc_install.yml
+++ b/files/ohpc_install.yml
@@ -122,8 +122,8 @@
                                 master_eth_internal='enahisic2i1'
                                 eth_provision='enahisic2i1'
                                 num_compute='3' 
-                                compute_prefix='d030'
-                                compute_regex='d030[1-3]'
+                                compute_prefix='d050'
+                                compute_regex='d050[1-3]'
                                 kargs=' modprobe.blacklist=hibmc_drm'
                         elif [ ${node} == 'tx2ohpc' ]; then
                                 master_ipoib_internal='ib0'

--- a/files/ohpc_test_suite.yml
+++ b/files/ohpc_test_suite.yml
@@ -70,22 +70,17 @@
 
                         if [ ${node} == 'qdfohpc' ]; then
                                 master_name='qdfohpc'
-                                cnode01='qdf01'
-                                cnode02='qdf02'
-                                cnode03='qdf03'
+                                cnodes=('qdf01' 'qdf02' 'qdf03')
                                 num_compute='3'
                                 compute_regex='qdf0[1-3]'
                         elif [ ${node} == 'd05ohpc' ]; then
                                 master_name='d05ohpc'
-                                cnode01='d0301'
-                                cnode02='d0302'
-                                cnode03='d0303'
+                                cnodes=('d0501' 'd0502' 'd0503')
                                 num_compute='3' 
                                 compute_regex='d030[1-3]'
                         elif [ ${node} == 'tx2ohpc' ]; then
                                 master_name='tx2ohpc'
-                                cnode01='tx201'
-                                cnode02='tx202'
+                                cnodes=('tx201' 'tx202')
                                 num_compute='2'
                                 compute_regex='tx20[1-2]'
                         fi
@@ -95,11 +90,13 @@
                         fi
                         git clone -b ${client_branch} https://github.com/Linaro/mr-provisioner-client.git ${WORKSPACE}/mr-provisioner-client
 
-                        master_ip=$( ./mr-provisioner-client/mrp_client.py --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token} net --action getip --machine ${master_name} --interface eth1)
-                        cnode01ip=$( ./mr-provisioner-client/mrp_client.py --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token} net --action getip --machine ${cnode01} --interface eth1)
-                        cnode02ip=$( ./mr-provisioner-client/mrp_client.py --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token} net --action getip --machine ${cnode02} --interface eth1)
-                        cnode03ip=$( ./mr-provisioner-client/mrp_client.py --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token} net --action getip --machine ${cnode03} --interface eth1)
+                        master_ip=$( ./mr-provisioner-client/mrp_client.py --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token} net --action getip --machine ${master_name} --interface eth1 )
 
+                        for i in "${cnodes[@]}"; 
+                        do 
+                                declare ip_${i}=$( ./mr-provisioner-client/mrp_client.py --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token} net --action getip --machine ${i} --interface eth1 )
+                        done
+                        
                         if [ ${method} == 'stateful' ]; then
                                 enable_warewulf=False
                         elif [ ${method} == 'stateless' ]; then
@@ -115,9 +112,7 @@
                         [sms]
                         ${master_ip}
                         [cnodes]
-                        ${cnode01ip}
-                        ${cnode02ip}
-                        ${cnode03ip}
+                        $(for i in "${cnodes[@]}"; do var=ip_${i}; echo -e "${!var}"; done)
                         [ionodes]
                         ${master_ip}
                         [devnodes]


### PR DESCRIPTION
The test suite job now reuses code from ohpc_install to be able to work with a cluster with any number of nodes in it, allowing for tx2 to properly run on it.

Concerning the D05 fix, it would seem the complete patch was dropped in a previous rebase, but now it's complete (again).