### PR TITLE
Add Infiniband installation for qdf cluster

### DIFF
--- a/files/ohpc_install.yml
+++ b/files/ohpc_install.yml
@@ -61,6 +61,8 @@
                         mr_provisioner_url='http://10.40.0.11:5000'
                         mr_provisioner_token=$(cat "/home/${NODE_NAME}/mrp_token")
 
+                        mellanox_iso_url="http://www.mellanox.com/downloads/ofed/MLNX_OFED-4.4-1.0.0.0/MLNX_OFED_LINUX-4.4-1.0.0.0-rhel7.5alternate-aarch64.iso"
+                        mellanox_iso_file="MLNX_OFED_LINUX-4.4-1.0.0.0-rhel7.5alternate-aarch64.iso"
                         force_service=True
                         sms_ipoib_internal='ib0'
                         cnodes_ipoib_internal='ib0'
@@ -114,6 +116,13 @@
                                 compute_regex='qdf0[1-3]'
                                 kargs=''
                                 additional_modules='qcom_emac'
+                                enable_opensm=True
+                                enable_ipoib=True
+                                enable_ifup=True
+                                enable_linux_ib=False
+                                enable_mellanox_ib=True
+                                mofed_install_opts="--distro rhel7.5alternate"
+                                enable_socket_direct=True
                         elif [ ${node} == 'd05ohpc' ]; then
                                 master_ipoib_internal='ib0'
                                 cnodes_ipoib_internal='ib0'
@@ -125,6 +134,13 @@
                                 compute_prefix='d050'
                                 compute_regex='d050[1-3]'
                                 kargs=' modprobe.blacklist=hibmc_drm'
+                                enable_opensm=False
+                                enable_ipoib=False
+                                enable_ifup=False
+                                enable_linux_ib=False
+                                enable_mellanox_ib=False
+                                mofed_install_opts=""
+                                enable_socket_direct=False
                         elif [ ${node} == 'tx2ohpc' ]; then
                                 master_ipoib_internal='ib0'
                                 cnodes_ipoib_internal='ib0'
@@ -136,6 +152,13 @@
                                 compute_prefix='tx20'
                                 compute_regex='tx20[1-2]'
                                 kargs=' console=tty0'
+                                enable_opensm=False
+                                enable_ipoib=False
+                                enable_ifup=False
+                                enable_linux_ib=False
+                                enable_mellanox_ib=False
+                                mofed_install_opts=""
+                                enable_socket_direct=False
                         fi
 
                         if [ -d ${WORKSPACE}/mr-provisioner-client ]; then
@@ -170,6 +193,8 @@
                         EOF
 
                         cat << EOF > ${WORKSPACE}/ohpc_installation.yml
+                        mellanox_iso_url: ${mellanox_iso_url}
+                        mellanox_iso_file: ${mellanox_iso_file}
                         sms_name: ${master_name}
                         sms_ip: ${master_ip}
                         sms_eth_internal: ${master_eth_internal}
@@ -189,6 +214,10 @@
                         enable_clustershell: ${enable_clustershell}
                         enable_ipmisol: ${enable_ipmisol}
                         enable_opensm: ${enable_opensm}
+                        enable_linux_ib: ${enable_linux_ib}
+                        enable_mellanox_ib: ${enable_mellanox_ib}
+                        mofed_install_opts: ${mofed_install_opts}
+                        enable_socket_direct: ${enable_socket_direct}
                         enable_ipoib: ${enable_ipoib}
                         enable_ganglia: ${enable_ganglia}
                         enable_genders: ${enable_genders}


### PR DESCRIPTION
The QDF cluster's IB is operational, and this patch makes use of these facilities and enables them with Mellanox OFED and Socket Direct support.