### PR TITLE
Disable extrae tests

### DIFF
--- a/files/ohpc_test_suite.yml
+++ b/files/ohpc_test_suite.yml
@@ -138,6 +138,8 @@
                             status: enable
                           - name: compilers
                             status: enable
+                          - name: extrae
+                            status: disable
                           - name: fftw
                             status: enable
                           - name: gsl


### PR DESCRIPTION
Extrae tests do not seem to work out of the box, those need disabling preceding more in depth investigation of the issue.