### PR TITLE
Add OpenMPI MTT Hello World TestPlan

### DIFF
--- a/files/ansible/deploy_mtt.yml
+++ b/files/ansible/deploy_mtt.yml
@@ -1,0 +1,97 @@
+- hosts: all
+  tasks:
+
+  - name: Install pip on master
+    yum:
+            name:
+              - python-devel
+              - python-pip
+              - flex
+              - postgresql-devel
+            state: latest
+    when:
+      - inventory_hostname in groups['sms']
+
+  - name: Add user test to master
+    user:
+      name: test
+      comment: Test User for Hello World MPI test
+      state: present
+    when:
+      - inventory_hostname in groups['sms']
+
+  - name: Propagate this to the computes in stateful
+    user:
+      name: test
+      comment: Test User for Hello World MPI test
+      state: present
+    when:
+      - inventory_hostname in groups['cnodes']
+      - enable_warewulf == false
+
+  - name: Propagate this to the computes in stateless
+    shell: wwsh file resync passwd shadow group
+    when:
+      - inventory_hostname in groups['sms']
+      - enable_warewulf == True
+
+  - name: Clone MTT repository
+    git:
+            repo: 'https://github.com/open-mpi/mtt.git'
+            dest: "{{ MTT_HOME }}" 
+            force: yes
+    when:
+      - inventory_hostname in groups['sms']
+
+  - name: Install python dependencies
+    shell: "pip install --upgrade pip && pip install -r {{ MTT_HOME }}/pyenv.txt"
+    when:
+      - inventory_hostname in groups['sms']
+
+  - name: Put in the Test Plan templates
+    template:
+            src: "templates/{{ item }}.ini.j2"
+            dest: "/home/test/mtt/samples/python/{{ item }}.ini"
+    with_items:
+            - "{{ test_plans }}"
+    when:
+      - inventory_hostname in groups['sms']
+        
+  - name: Create directory because MTT
+    file:
+            path: "/opt/mtt/samples/python/"
+            state: directory
+    when:
+      - inventory_hostname in groups['sms']
+
+  - name: Execute Hello World MTT test
+    shell: "{{ MTT_HOME }}/pyclient/pymtt.py {{ MTT_HOME }}/samples/python/{{ item }}.ini --description {{ item }} --scratch-dir {{ MTT_HOME }}"
+    environment:
+            MTT_HOME: "{{ MTT_HOME }}"
+    with_items:
+            - "{{ test_plans }}"
+    when:
+      - inventory_hostname in groups['sms']
+
+  - name: Find the JUnit results
+    find:
+            paths: "{{ MTT_HOME }}"
+            patterns: "{{ item }}.xml"
+    register: junit_results_path
+    failed_when: junit_results_path.matched == 0
+    with_items:
+            - "{{ test_plans }}"
+    when:
+      - inventory_hostname in groups['sms']
+
+  - debug: var=junit_results_path
+
+  - name: Fetch the results
+    fetch: 
+        src: "{{ item.files[0].path }}"
+        dest: "{{ workspace }}/results/"
+        flat: yes
+    with_items:
+            - "{{ junit_results_path.results }}"
+    when:
+      - inventory_hostname in groups['sms']

--- a/files/ansible/templates/ompi_hello_world.ini.j2
+++ b/files/ansible/templates/ompi_hello_world.ini.j2
@@ -1,0 +1,56 @@
+#Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+#
+
+# Set defaults
+[MTTDefaults]
+description = MPI hello world
+platform = pluto
+
+# Get the system profile
+[Profile:Installed]
+
+#======================================================================
+# Test get phases - get the tests that the
+# target software will run.
+#======================================================================
+
+[ASIS TestGet:HelloWorld]
+plugin = Copytree
+src = /opt/mtt/samples/python/
+
+#======================================================================
+# Test build phase
+#======================================================================
+
+[TestBuild:HelloWorld]
+parent = TestGet:HelloWorld
+plugin = Shell
+
+# Use our built ompi install
+command = mpicc /home/test/mtt/samples/python/mpi_hello_world.c -o mpi_hello_world 
+#======================================================================
+# Define some default launcher execution parameters
+#======================================================================
+
+[LauncherDefaults:SLURM]
+plugin = SLURM
+command = srun
+job_name = MTT_TEST
+options = -N {{ num_compute }} --mpi={{ mpi_type | default("pmix") }} 
+
+#----------------------------------------------------------------------
+[TestRun:HelloWorld]
+plugin = SLURM
+parent = TestBuild:HelloWorld
+test_list = mpi_hello_world
+
+#======================================================================
+# Reporter phase
+#======================================================================
+[Reporter:Console]
+plugin = TextFile
+
+[Reporter:JunitXML]
+plugin = JunitXML
+filename=ompi_hello_world.xml
+

--- a/files/deploy_mtt.yml
+++ b/files/deploy_mtt.yml
@@ -1,0 +1,136 @@
+ - job:
+         name: deploy_mtt 
+         description: "This is the job to run OpenMPI's MTT on the clusters"
+         project-type: freestyle
+         block-downstream: false
+         concurrent: true
+         properties:
+                 - authorization:
+                         hpc-sig-admin:
+                                 - credentials-create
+                                 - credentials-delete
+                                 - credentials-manage-domains
+                                 - credentials-update
+                                 - credentials-view
+                                 - job-build
+                                 - job-cancel
+                                 - job-configure
+                                 - job-delete
+                                 - job-discover
+                                 - job-move
+                                 - job-read
+                                 - job-status
+                                 - job-workspace
+                                 - ownership-jobs
+                                 - run-delete
+                                 - run-update
+                                 - scm-tag
+                         hpc-sig-devel:
+                                 - job-build
+                                 - job-read
+         parameters:
+                 - node:
+                         name: cluster
+                         allowed-slaves:
+                                 - tx2ohpc
+                                 - d05ohpc
+                                 - qdfohpc
+                         allowed-multiselect: True
+                         description: 'Which cluster to use'
+                 - string:
+                         name: client_branch
+                         default: 'master'
+                         description: 'Branch name of the MrP client to use'
+                 - string:
+                         name: automation_branch
+                         default: 'master'
+                         description: 'Branch name of the hpc_lab_setup to use'
+                 - choice:
+                         name: method
+                         choices:
+                                 - stateful
+                                 - stateless
+                         default: 'stateful'
+                         description: 'The type of OHPC install to do'
+         builders:
+                 - shell: |
+                        #!/bin/bash
+                        set -ex
+
+                        mr_provisioner_url='http://10.40.0.11:5000'
+                        mr_provisioner_token=$(cat "/home/${NODE_NAME}/mrp_token")
+
+                        MTT_HOME='/home/test/mtt'
+
+                        if [ ${method} == 'stateful' ]; then
+                                enable_warewulf='False'
+                        else
+                                enable_warewulf='True'
+                        fi
+
+                        if [ ${cluster} == 'd05ohpc' ]; then
+                                master_name='d05ohpc'
+                                cnodes=('d0501' 'd0502' 'd0503')
+                                num_compute='3'
+                        elif [ ${cluster} == 'tx2ohpc' ]; then
+                                master_name='tx2ohpc'
+                                cnodes=('tx201' 'tx202')
+                                num_compute='2'
+                        elif [ ${cluster} == 'qdfohpc' ]; then
+                                master_name='qdfohpc'
+                                cnodes=('qdf01' 'qdf02' 'qdf03')
+                                num_compute='3'
+                        fi
+
+                        if [ -d ${WORKSPACE}/mr-provisioner-client ]; then
+                            rm -rf ${WORKSPACE}/mr-provisioner-client
+                        fi
+                        git clone -b ${client_branch} https://github.com/Linaro/mr-provisioner-client.git ${WORKSPACE}/mr-provisioner-client
+
+                        master_ip=$( ./mr-provisioner-client/mrp_client.py --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token} net --action getip --machine ${master_name} --interface eth1 )
+
+                        for i in "${cnodes[@]}";
+                        do
+                                declare ip_${i}=$( ./mr-provisioner-client/mrp_client.py --mrp-url=${mr_provisioner_url} --mrp-token=${mr_provisioner_token} net --action getip --machine ${i} --interface eth1 )
+                        done
+
+                        cat << EOF > ${WORKSPACE}/hosts
+                        [sms]
+                        ${master_ip}
+                        [cnodes]
+                        $(for i in "${cnodes[@]}"; do var=ip_${i}; echo -e "${!var}"; done)
+                        [ionodes]
+                        ${master_ip}
+                        [devnodes]
+                        ${master_ip}
+                        EOF
+
+                        cat << EOF > ${WORKSPACE}/mtt_args.yml
+                        num_compute: ${num_compute}
+                        enable_warewulf: ${enable_warewulf}
+                        MTT_HOME: ${MTT_HOME}
+                        workspace: ${WORKSPACE}
+                        test_plans:
+                        - ompi_hello_world
+                        EOF
+
+                        if [ -d ${WORKSPACE}/results ]; then
+                            rm -rf ${WORKSPACE}/results
+                        fi
+                        mkdir ${WORKSPACE}/results
+
+                        if [ -d ${WORKSPACE}/hpc_lab_setup ]; then
+                            rm -rf ${WORKSPACE}/hpc_lab_setup
+                        fi
+                        git clone -b ${automation_branch} https://github.com/Linaro/hpc_lab_setup.git ${WORKSPACE}/hpc_lab_setup
+
+                        eval `ssh-agent`
+                        ssh-add
+                        ANSIBLE_CONFIG="${WORKSPACE}/hpc_lab_setup/files/ansible/ansible.cfg" ansible-playbook -v -u root "${WORKSPACE}/hpc_lab_setup/files/ansible/deploy_mtt.yml" -i "${WORKSPACE}/hosts" --extra-vars="@${WORKSPACE}/mtt_args.yml"
+                        ssh-agent -k 
+
+         publishers:
+                 - junit:
+                        results: "results/*.xml, results/**/*.xml, results/**/**/*.xml" 
+                        keep-long-stdio: yes
+                        allow-empty-results: yes

--- a/tasks/jenkins_jobs.yml
+++ b/tasks/jenkins_jobs.yml
@@ -13,6 +13,7 @@
           - ohpc_install
           - ohpc_test_suite
           - cluster_provision
+          - deploy_mtt
 
 - name: Copy yaml view definition(s)
   copy:
@@ -35,3 +36,4 @@
           - benchmark_view
           - ohpc_view
           - provisioning_view
+          - deploy_mtt


### PR DESCRIPTION
This new job deploys OpenMPI's MPI Testing Tool, and makes it execute a "Hello World" test, using preinstalled openmpi libraries and tools, as well as slurm to dispatch the job.

It serves as a basis for further "test plans".
Tested on qdf and tx2 cluster (so stateless and stateful OpenHPC installs).