### PR TITLE
Add snapshot building to MTT helloworld

### DIFF
--- a/files/ansible/deploy_mtt.yml
+++ b/files/ansible/deploy_mtt.yml
@@ -35,6 +35,13 @@
       - inventory_hostname in groups['sms']
       - enable_warewulf == True
 
+  - name: Clean the MTT_SCRATCH directory
+    file:
+            path: "{{ MTT_SCRATCH }}"
+            state: absent
+    when:
+      - inventory_hostname in groups['sms']
+
   - name: Clone MTT repository
     git:
             repo: 'https://github.com/open-mpi/mtt.git'
@@ -56,16 +63,23 @@
             - "{{ test_plans }}"
     when:
       - inventory_hostname in groups['sms']
-        
-  - name: Create directory because MTT
+
+  - name: Create Directory for Snapshot module template
     file:
-            path: "/opt/mtt/samples/python/"
+            path: "/opt/ohpc/pub/moduledeps/gnu8/openmpi4"
             state: directory
+    when:
+      - inventory_hostname in groups['sms']
+        
+  - name: Put in the Lmod OpenMPI Snapshot module template
+    template:
+            src: "templates/ompi_snapshot_lmod.j2"
+            dest: "/opt/ohpc/pub/moduledeps/gnu8/openmpi4/4.1.0"
     when:
       - inventory_hostname in groups['sms']
 
   - name: Execute Hello World MTT test
-    shell: "{{ MTT_HOME }}/pyclient/pymtt.py {{ MTT_HOME }}/samples/python/{{ item }}.ini --description {{ item }} --scratch-dir {{ MTT_HOME }}"
+    shell: "{{ MTT_HOME }}/pyclient/pymtt.py {{ MTT_HOME }}/samples/python/{{ item }}.ini --description {{ item }} --scratch-dir {{ MTT_SCRATCH }}"
     environment:
             MTT_HOME: "{{ MTT_HOME }}"
     with_items:
@@ -75,7 +89,7 @@
 
   - name: Find the JUnit results
     find:
-            paths: "{{ MTT_HOME }}"
+            paths: "{{ MTT_SCRATCH }}"
             patterns: "{{ item }}.xml"
     register: junit_results_path
     failed_when: junit_results_path.matched == 0

--- a/files/ansible/templates/ompi_hello_world.ini.j2
+++ b/files/ansible/templates/ompi_hello_world.ini.j2
@@ -4,10 +4,24 @@
 # Set defaults
 [MTTDefaults]
 description = MPI hello world
-platform = pluto
+platform = {{ cluster }}
 
 # Get the system profile
 [Profile:Installed]
+
+[ASIS MiddlewareGet:OMPIMaster]
+plugin = OMPI_Snapshot
+url =  https://download.open-mpi.org/nightly/open-mpi/master
+version_file = /home/test/mtt/mttscratch/VERSION
+mpi_name = ompi-nightly-master
+
+#----------------------------------------------------------------------
+
+[ASIS MiddlewareBuild:OMPIMaster]
+parent = MiddlewareGet:OMPIMaster
+plugin = Autotools
+configure_options = --enable-debug
+make_options = -j 
 
 #======================================================================
 # Test get phases - get the tests that the
@@ -16,7 +30,7 @@ platform = pluto
 
 [ASIS TestGet:HelloWorld]
 plugin = Copytree
-src = /opt/mtt/samples/python/
+src = {{ MTT_SCRATCH }}
 
 #======================================================================
 # Test build phase
@@ -28,6 +42,19 @@ plugin = Shell
 
 # Use our built ompi install
 command = mpicc /home/test/mtt/samples/python/mpi_hello_world.c -o mpi_hello_world 
+modules = openmpi3
+modules_unload = openmpi4/4.1.0
+#======================================================================
+
+[TestBuild:HelloWorldMaster]
+parent = TestGet:HelloWorld
+plugin = Shell
+middleware = MiddlewareBuild:OMPIMaster
+
+# Use our built ompi install
+command = mpicc /home/test/mtt/samples/python/mpi_hello_world.c -o mpi_hello_world_master 
+modules = openmpi4/4.1.0
+modules_unload = openmpi3
 #======================================================================
 # Define some default launcher execution parameters
 #======================================================================
@@ -44,6 +71,11 @@ plugin = SLURM
 parent = TestBuild:HelloWorld
 test_list = mpi_hello_world
 
+#----------------------------------------------------------------------
+[TestRun:HelloWorldMaster]
+plugin = SLURM
+parent = TestBuild:HelloWorldMaster
+test_list = mpi_hello_world_master
 #======================================================================
 # Reporter phase
 #======================================================================

--- a/files/ansible/templates/ompi_snapshot_lmod.j2
+++ b/files/ansible/templates/ompi_snapshot_lmod.j2
@@ -1,0 +1,25 @@
+#%Module1.0#####################################################################
+
+proc ModulesHelp { } {
+
+puts stderr " "
+puts stderr "This module loads the openmpi4 library built with the gnu8 toolchain."
+puts stderr "\nVersion 4.1.0\n"
+
+}
+module-whatis "Name: openmpi4 built with gnu8 toolchain"
+module-whatis "Version: 4.1.0"
+module-whatis "Category: runtime library"
+module-whatis "Description: A powerful implementation of MPI"
+module-whatis "URL: http://www.open-mpi.org"
+
+set     version			    4.1.0
+
+setenv          MPI_DIR             /home/test/mtt/mttscratch/MiddlewareBuild_OMPIMaster/
+prepend-path    PATH                /home/test/mtt/mttscratch/MiddlewareBuild_OMPIMaster/bin/
+prepend-path    MANPATH             /home/test/mtt/mttscratch/MiddlewareBuild_OMPIMaster/share/man
+prepend-path	LD_LIBRARY_PATH	    /home/test/mtt/mttscratch/MiddlewareBuild_OMPIMaster/lib
+prepend-path    MODULEPATH          /opt/ohpc/pub/moduledeps/gnu8-openmpi3
+prepend-path    PKG_CONFIG_PATH     /opt/ohpc/pub/mpi/openmpi3-gnu8/3.1.2/lib/pkgconfig
+
+family "MPI"

--- a/files/deploy_mtt.yml
+++ b/files/deploy_mtt.yml
@@ -81,6 +81,10 @@
                                 master_name='qdfohpc'
                                 cnodes=('qdf01' 'qdf02' 'qdf03')
                                 num_compute='3'
+                        elif [ ${cluster} == 'x86ohpc' ]; then
+                                master_name='x86ohpc'
+                                cnodes=('x8601' 'x8602')
+                                num_compute='2'
                         fi
 
                         if [ -d ${WORKSPACE}/mr-provisioner-client ]; then
@@ -110,6 +114,8 @@
                         num_compute: ${num_compute}
                         enable_warewulf: ${enable_warewulf}
                         MTT_HOME: ${MTT_HOME}
+                        MTT_SCRATCH: ${MTT_HOME}/mttscratch
+                        cluster: ${cluster}
                         workspace: ${WORKSPACE}
                         test_plans:
                         - ompi_hello_world


### PR DESCRIPTION
This patch adds the building of a snapshot of OpenMPI to be built and used to perform the hello world test, in addition to OpenHPC's OpenMPI stack.