### PR TITLE
Add Tensorflow Build as Job and Ansible Role

### DIFF
--- a/files/ansible/build_tensorflow.yml
+++ b/files/ansible/build_tensorflow.yml
@@ -1,0 +1,4 @@
+---
+- hosts: target
+  roles:
+          - tensorflow

--- a/files/ansible/install_python3.yml
+++ b/files/ansible/install_python3.yml
@@ -1,0 +1,21 @@
+---
+- hosts: target
+  tasks:
+          - name: Install EPEL release
+            yum:
+                    name: epel-release
+                    state: latest
+
+          - name: Install Python3.6 from EPEL
+            yum:
+                    name:
+                            - python36
+                            - python36-devel
+                            - python-devel
+                            - python36-setuptools
+                            - python3-pip
+                            - python-setuptools
+                            - python36-cffi
+                            - libyaml
+                            - libyaml-devel
+                    state: latest

--- a/files/ansible/roles/tensorflow/defaults/main.yml
+++ b/files/ansible/roles/tensorflow/defaults/main.yml
@@ -1,0 +1,112 @@
+---
+python3: "/usr/bin/python3"
+user: "builder"
+build_id: "42"
+dir_root: "/home/{{ user }}/{{ build_id }}"
+dir_home: "{{ dir_root }}/tensorflow_build"
+dir_repo: "{{ dir_root }}/repo_tensorflow"
+dir_built: "{{ dir_root }}/built_tarballs"
+venv_path: "{{ dir_root }}/virtualenv"
+
+
+# NumPy variables
+# See : https://github.com/ansible/ansible/issues/8603 
+# (No it's not "resolved", it's "bad design we can't fix")
+numpy_version: "1.17.3"
+numpy_dir_base: "{{ dir_home }}/numpy/{{ numpy_version}}"
+numpy_dir_src: "{{ numpy_dir_base }}/numpy-{{ numpy_version }}"
+numpy_dir_output: "{{ numpy_dir_src }}/dist"
+numpy:
+       release_url: "https://github.com/numpy/numpy/releases/download/v{{ numpy_version }}/numpy-{{ numpy_version }}.zip"
+       release_zip: "numpy-{{ numpy_version }}.zip"
+       release_sha256: "a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e"
+       wheel: "{{ numpy_dir_output }}/numpy-{{ numpy_version }}-cp36-cp36m-linux_aarch64.whl"
+       patching_required: true
+       patch: 'numpy_centos7_aarch64.patch'
+       built_tarball: "numpy_{{ numpy_version }}_{{ build_id }}.tar.gz"
+
+# TensorFlow variables
+tensorflow_version: "1.15.0"
+tensorflow_dir_base: "{{ dir_home }}/tensorflow/{{ tensorflow_version}}"
+tensorflow_dir_src: "{{ tensorflow_dir_base }}/tensorflow-{{ tensorflow_version }}"
+tensorflow_configure: "{{ tensorflow_dir_src }}/configure"
+tensorflow_dir_output: "/tmp/tensorflow_pkg"
+tensorflow:
+       release_url: "https://github.com/tensorflow/tensorflow/archive/v{{ tensorflow_version }}.zip"
+       release_zip: "tensorflow-{{ tensorflow_version }}.zip"
+       wheel: "{{ tensorflow_dir_output }}/tensorflow-{{ tensorflow_version }}-cp36-cp36m-linux_{{ arch }}.whl"
+       patching_required: true
+       patch: 'patch_bazelbuild.patch'
+       built_tarball: "tensorflow_{{ tensorflow_version }}_{{ build_id }}.tar.gz"
+       cxx_optimizations:
+               - "-D_GLIBCXX_USE_CXX11_ABI=0"
+       c_optimizations:
+               - "-funsafe-math-optimizations"
+               - "-ftree-vectorize"
+               - "-fomit-frame-pointer"
+
+# Bazel variables
+bazel_version: "0.24.1"
+bazel_dir_base: "{{ dir_home }}/bazel"
+bazel_dir_src: "{{ bazel_dir_base }}/{{ bazel_version}}"
+bazel_dir_output: "{{ bazel_dir_src }}/output"
+bazel:
+       release_url: "https://github.com/bazelbuild/bazel/releases/download/{{ bazel_version }}/bazel-{{ bazel_version }}-dist.zip"
+       release_zip: "bazel-{{ bazel_version }}-dist.zip"
+       binary: "{{ bazel_dir_output }}/bazel"
+       patching_required: false
+       built_tarball: "bazel_{{ bazel_version }}_{{ build_id }}.tar.gz"
+
+ohpc_toolchain_base_dir: "/opt/ohpc/pub/compiler/gcc/8.3.0"
+ohpc_toolchain_lib_dir: "{{ ohpc_toolchain_base_dir }}/lib64"
+LD_LIBRARY_PATH: "/opt/ohpc/pub/libs/gnu8/hdf5/1.10.5/lib:/opt/ohpc/pub/libs/gnu8/openblas/0.3.5/lib:/opt/ohpc/pub/mpi/openmpi3-gnu8/3.1.4/lib:/opt/ohpc/pub/compiler/gcc/8.3.0/lib64"
+LD_INCLUDE_PATH: "/opt/ohpc/pub/libs/gnu8/hdf5/1.10.5/include:/opt/ohpc/pub/libs/gnu8/openblas/0.3.5/include:/opt/ohpc/pub/mpi/openmpi3-gnu8/3.1.4/include::/opt/ohpc/pub/compiler/gcc/8.3.0/lib64"
+openblas_library_path: "/opt/ohpc/pub/libs/gnu8/openblas/0.3.5/lib"
+openblas_include_path: "/opt/ohpc/pub/libs/gnu8/openblas/0.3.5/include"
+
+fftw_library_path: "/opt/ohpc/pub/libs/gnu8/openmpi3/fftw/3.3.8/lib"
+fftw_include_path: "/opt/ohpc/pub/libs/gnu8/openmpi3/fftw/3.3.8/include"
+
+hdf5_base_dir: "/opt/ohpc/pub/libs/gnu8/hdf5/1.10.5"
+
+### BUILD DEPENDENCIES
+# Non OHPC, non python, non java
+tf_build_dependencies:
+        - "@Development Tools"
+        - createrepo
+        - vim
+        - wget
+        - unzip
+        - tar
+        - redhat-lsb-core
+
+ohpc_release_url: "http://build.openhpc.community/OpenHPC:/1.3/CentOS_7/aarch64/ohpc-release-1.3-1.el7.aarch64.rpm"
+
+tf_build_ohpc_dependencies:
+        - lmod-ohpc
+        - openmpi3-gnu8-ohpc
+        - ohpc-gnu8-perf-tools
+        - ohpc-gnu8-io-libs
+        - ohpc-gnu8-python-libs
+        - ohpc-gnu8-runtimes
+        - ohpc-gnu8-serial-libs
+        - ohpc-gnu8-parallel-libs
+        - fftw-gnu8-openmpi3-ohpc
+        - lmod-defaults-gnu8-openmpi3-ohpc
+
+tf_build_java8:
+        - java-1.8.0-openjdk
+        - java-1.8.0-openjdk-devel
+
+tf_build_py3_dependencies:
+        - pip
+        - Cython
+        - six
+        - wheel
+        - setuptools
+        - mock
+        - "future>=0.17.1"
+
+tf_build_keras:
+        - "keras_applications==1.0.6"
+        - "keras_preprocessing==1.0.5"

--- a/files/ansible/roles/tensorflow/defaults/main.yml
+++ b/files/ansible/roles/tensorflow/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+arch: "aarch64"
+distribution: "el7"
+
 python3: "/usr/bin/python3"
 user: "builder"
 build_id: "42"
@@ -7,6 +10,9 @@ dir_home: "{{ dir_root }}/tensorflow_build"
 dir_repo: "{{ dir_root }}/repo_tensorflow"
 dir_built: "{{ dir_root }}/built_tarballs"
 venv_path: "{{ dir_root }}/virtualenv"
+
+# rpm build variables
+dir_rpmbuilt: "/home/{{ user }}/rpmbuild/RPMS/{{ arch }}"
 
 
 # NumPy variables
@@ -46,7 +52,9 @@ tensorflow:
                - "-fomit-frame-pointer"
 
 # Bazel variables
-bazel_version: "0.24.1"
+bazel_version: "0.26.1"
+bazel_minorversion: "0"
+bazel_rpm: "{{ dir_rpmbuilt }}/bazel-{{ bazel_version }}-{{ bazel_minorversion }}.{{ distribution }}.{{ arch }}.rpm"
 bazel_dir_base: "{{ dir_home }}/bazel"
 bazel_dir_src: "{{ bazel_dir_base }}/{{ bazel_version}}"
 bazel_dir_output: "{{ bazel_dir_src }}/output"
@@ -74,6 +82,7 @@ hdf5_base_dir: "/opt/ohpc/pub/libs/gnu8/hdf5/1.10.5"
 tf_build_dependencies:
         - "@Development Tools"
         - createrepo
+        - rpm-build
         - vim
         - wget
         - unzip
@@ -95,8 +104,8 @@ tf_build_ohpc_dependencies:
         - lmod-defaults-gnu8-openmpi3-ohpc
 
 tf_build_java8:
-        - java-1.8.0-openjdk
-        - java-1.8.0-openjdk-devel
+        - java-11-openjdk
+        - java-11-openjdk-devel
 
 tf_build_py3_dependencies:
         - pip

--- a/files/ansible/roles/tensorflow/defaults/main.yml
+++ b/files/ansible/roles/tensorflow/defaults/main.yml
@@ -18,7 +18,7 @@ dir_rpmbuilt: "/home/{{ user }}/rpmbuild/RPMS/{{ arch }}"
 # NumPy variables
 # See : https://github.com/ansible/ansible/issues/8603 
 # (No it's not "resolved", it's "bad design we can't fix")
-numpy_version: "1.17.3"
+numpy_version: "1.17.4"
 numpy_dir_base: "{{ dir_home }}/numpy/{{ numpy_version}}"
 numpy_dir_src: "{{ numpy_dir_base }}/numpy-{{ numpy_version }}"
 numpy_dir_output: "{{ numpy_dir_src }}/dist"

--- a/files/ansible/roles/tensorflow/tasks/build_bazel.yml
+++ b/files/ansible/roles/tensorflow/tasks/build_bazel.yml
@@ -1,0 +1,58 @@
+---
+- name: Delete build dirs bazel
+  file:
+          path: "{{ item }}"       
+          state: absent
+  with_items:
+          - "{{ bazel_dir_base }}"
+          - "{{ bazel_dir_src }}"
+          - "{{ bazel_dir_output }}"
+
+- name: Create build dirs bazel
+  file:
+          path: "{{ item }}"       
+          state: directory
+          mode: '0755'
+          owner: "{{ user }}"
+          group: "{{ user }}"
+  with_items:
+          - "{{ bazel_dir_base }}"
+          - "{{ bazel_dir_src }}"
+          - "{{ bazel_dir_output }}"
+
+- name: Fetch bazel release tarball
+  get_url:
+          url: "{{ bazel.release_url }}"
+          dest: "{{ bazel_dir_base }}"
+
+- name: Unzip the release
+  unarchive:
+          src: "{{ bazel_dir_base }}/{{ bazel.release_zip }}"
+          remote_src: yes
+          dest: "{{ bazel_dir_src }}"
+
+- name: Build bazel
+  shell: "EXTRA_BAZEL_ARGS='--host_javabase=@local_jdk//:jdk' ./compile.sh"
+  args:
+          chdir: "{{ bazel_dir_src }}"
+          executable: "/bin/bash"
+  register: bazel_build_log
+- debug: var=bazel_build_log
+
+- name: Tar-up bazel output
+  archive:
+          path: "{{ bazel_dir_output }}"
+          dest: "{{ dir_built }}/{{ bazel.built_tarball }}"
+          format: gz
+
+- name: Install bazel
+  copy:
+          src: "{{ bazel.binary }}"
+          remote_src: yes
+          dest: "/usr/local/bin"
+          owner: root
+          group: root
+          mode: '0755'
+  become: yes
+  become_user: root
+  become_method: sudo

--- a/files/ansible/roles/tensorflow/tasks/build_bazel.yml
+++ b/files/ansible/roles/tensorflow/tasks/build_bazel.yml
@@ -20,39 +20,25 @@
           - "{{ bazel_dir_src }}"
           - "{{ bazel_dir_output }}"
 
-- name: Fetch bazel release tarball
-  get_url:
-          url: "{{ bazel.release_url }}"
-          dest: "{{ bazel_dir_base }}"
-
-- name: Unzip the release
-  unarchive:
-          src: "{{ bazel_dir_base }}/{{ bazel.release_zip }}"
-          remote_src: yes
-          dest: "{{ bazel_dir_src }}"
+- name: Fetch rpm spec for bazel
+  template:
+          src: "bazel.spec.j2"
+          dest: "{{ bazel_dir_src }}/bazel.spec"
+          owner: "{{ user }}"
+          group: "{{ user }}"
 
 - name: Build bazel
-  shell: "EXTRA_BAZEL_ARGS='--host_javabase=@local_jdk//:jdk' ./compile.sh"
+  shell: "ml unload ohpc && rpmbuild -ba {{ bazel_dir_src }}/bazel.spec"
   args:
           chdir: "{{ bazel_dir_src }}"
           executable: "/bin/bash"
   register: bazel_build_log
 - debug: var=bazel_build_log
 
-- name: Tar-up bazel output
-  archive:
-          path: "{{ bazel_dir_output }}"
-          dest: "{{ dir_built }}/{{ bazel.built_tarball }}"
-          format: gz
-
 - name: Install bazel
-  copy:
-          src: "{{ bazel.binary }}"
-          remote_src: yes
-          dest: "/usr/local/bin"
-          owner: root
-          group: root
-          mode: '0755'
+  yum:
+          name: "{{ bazel_rpm }}"
+          state: present
   become: yes
   become_user: root
   become_method: sudo

--- a/files/ansible/roles/tensorflow/tasks/build_numpy.yml
+++ b/files/ansible/roles/tensorflow/tasks/build_numpy.yml
@@ -1,0 +1,63 @@
+---
+- name: Create build dirs numpy
+  file:
+          path: "{{ item }}"       
+          state: directory
+          mode: '0755'
+          owner: "{{ user }}"
+          group: "{{ user }}"
+  with_items:
+          - "{{ numpy_dir_base }}"
+          - "{{ numpy_dir_src }}"
+          - "{{ numpy_dir_output }}"
+
+- name: Fetch numpy release tarball
+  get_url:
+          url: "{{ numpy.release_url }}"
+          dest: "{{ numpy_dir_base }}"
+
+- name: Unzip the release
+  unarchive:
+          src: "{{ numpy_dir_base }}/{{ numpy.release_zip }}"
+          remote_src: yes
+          dest: "{{ numpy_dir_base }}"
+  no_log: true
+
+- name: Make sure numpy hooks up to environment
+  template:
+          src: "numpy-site.cfg.j2"
+          dest: "/home/{{ user }}/.numpy-site.cfg"
+
+- name: Get patch workaround for gcc bug
+  template:
+          src: "{{ numpy.patch }}.j2"
+          dest: "{{ numpy_dir_src }}/{{ numpy.patch }}"
+  when: numpy.patching_required == true 
+
+- name: Apply patch
+  shell: "patch -p0 -i {{ numpy_dir_src }}/{{ numpy.patch }}"
+  args:
+          chdir: "{{ numpy_dir_src }}"
+          executable: "/bin/bash"
+  when: "{{ numpy.patching_required }}"
+  
+- name: Build numpy
+  shell: "source {{ venv_path }}/bin/activate && {{ numpy_dir_src }}/setup.py build bdist_wheel"
+  args:
+          chdir: "{{ numpy_dir_src }}"
+          executable: "/bin/bash"
+  register: numpy_build_log
+- debug: var=numpy_build_log
+
+- name: Install numpy from wheel
+  pip:
+          name: "{{ numpy.wheel }}"
+          virtualenv: "{{ venv_path }}"
+  register: numpy_install_log
+- debug: var=numpy_install_log
+
+- name: Tar-up numpy output
+  archive:
+          path: "{{ numpy_dir_output }}"
+          dest: "{{ dir_built }}/{{ numpy.built_tarball }}"
+          format: gz

--- a/files/ansible/roles/tensorflow/tasks/build_tensorflow.yml
+++ b/files/ansible/roles/tensorflow/tasks/build_tensorflow.yml
@@ -1,0 +1,102 @@
+---
+- name: Create build dirs tensorflow
+  file:
+          path: "{{ item }}"       
+          state: directory
+          mode: '0755'
+          owner: "{{ user }}"
+          group: "{{ user }}"
+  with_items:
+          - "{{ tensorflow_dir_base }}"
+          - "{{ tensorflow_dir_src }}"
+          - "{{ tensorflow_dir_output }}"
+
+- name: Fetch tensorflow release tarball
+  get_url:
+          url: "{{ tensorflow.release_url }}"
+          dest: "{{ tensorflow_dir_base }}"
+
+- name: Unzip the release
+  unarchive:
+          src: "{{ tensorflow_dir_base }}/{{ tensorflow.release_zip }}"
+          remote_src: yes
+          dest: "{{ tensorflow_dir_base }}"
+  no_log: true
+
+- name: Get the tensorflow configure scipt
+  template:
+          src: "configure_tensorflow.sh.j2"
+          dest: "{{ tensorflow_dir_src }}/configure_tensorflow.sh"
+          mode: '0755'
+          owner: "{{ user }}"
+          group: "{{ user }}"
+
+- name: Configure tensorflow
+  shell: "./configure_tensorflow.sh"
+  args:
+          chdir: "{{ tensorflow_dir_src }}"
+          executable: "/bin/bash"
+  register: tensorflow_configure_log
+- debug: var=tensorflow_configure_log
+
+- name: Get patch for bazel missing requirements
+  template:
+          src: "{{ tensorflow.patch }}.j2"
+          dest: "{{ tensorflow_dir_src }}/{{ tensorflow.patch }}"
+          mode: '0755'
+          owner: "{{ user }}"
+          group: "{{ user }}"
+  when: tensorflow.patching_required
+
+- name: Apply patch
+  shell: "patch -p0 -i {{ tensorflow_dir_src }}/{{ tensorflow.patch }}"
+  args:
+          chdir: "{{ tensorflow_dir_src }}"
+          executable: "/bin/bash"
+  when: tensorflow.patching_required 
+
+- name: Get the tensorflow build scipt
+  template:
+          src: "build_tensorflow.sh.j2"
+          dest: "{{ tensorflow_dir_src }}/build_tensorflow.sh"
+          mode: '0755'
+          owner: "{{ user }}"
+          group: "{{ user }}"
+
+- name: Build tensorflow
+  shell: "./build_tensorflow.sh"
+  args:
+          chdir: "{{ tensorflow_dir_src }}"
+          executable: "/bin/bash"
+  register: tensorflow_build_log
+- debug: var=tensorflow_build_log
+
+- name: Build tensorflow package
+  shell: "bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg"
+  args:
+          chdir: "{{ tensorflow_dir_src }}"
+          executable: "/bin/bash"
+  register: tensorflow_build_pkg_log
+- debug: var=tensorflow_build_pkg_log
+
+- name: Tar-up tensorflow output
+  archive:
+          path: "{{ tensorflow_dir_output }}"
+          dest: "{{ dir_built }}/{{ tensorflow.built_tarball }}"
+          format: gz
+
+- name: Configure tensorflow
+  shell: "source {{ venv_path }}/bin/activate && HDF5_DIR={{ hdf5_base_dir }} pip install h5py"
+  args:
+          chdir: "{{ tensorflow_dir_src }}"
+          executable: "/bin/bash"
+  register: h5py_install_log
+- debug: var=h5py_install_log
+
+- name: Install tensorflow
+  pip:
+          name: "{{ tensorflow.wheel }}"
+          virtualenv: "{{ venv_path }}"
+  register: tensorflow_install_log
+- debug: var=tensorflow_install_log
+

--- a/files/ansible/roles/tensorflow/tasks/install_bazel.yml
+++ b/files/ansible/roles/tensorflow/tasks/install_bazel.yml
@@ -1,0 +1,16 @@
+---
+- name: Get the bazel_repo file for yum
+  template:
+          src: bazel.repo.j2
+          dest: /etc/yum.repos.d/bazel.repo
+
+- name: Clean yum cache
+  shell: "yum clean all"
+
+- name: Repopulate yum cache
+  shell: "yum makecache"
+
+- name: Install bazel from the repo
+  yum:
+          name: bazel-{{ bazel_version }}
+          state: present

--- a/files/ansible/roles/tensorflow/tasks/main.yml
+++ b/files/ansible/roles/tensorflow/tasks/main.yml
@@ -22,6 +22,11 @@
   become_user: "{{ user }}"
   become_method: su
   become_flags: "-s /bin/bash"
+  when: build_bazel == true
+
+- name: Install Bazel (no build)
+  import_tasks: install_bazel.yml
+  when: build_bazel == false
 
 - name: Build numpy
   import_tasks: build_numpy.yml

--- a/files/ansible/roles/tensorflow/tasks/main.yml
+++ b/files/ansible/roles/tensorflow/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+- name: Install dependencies
+  import_tasks: pre_build.yml
+
+- name: Install python3 dependencies
+  import_tasks: pre_build_venv.yml
+  become: yes
+  become_user: "{{ user }}"
+  become_method: su
+  become_flags: "-s /bin/bash"
+
+- name: Make sure env is good
+  import_tasks: pre_build_test.yml
+  become: yes
+  become_user: "{{ user }}"
+  become_method: su
+  become_flags: "-s /bin/bash"
+
+- name: Build Bazel
+  import_tasks: build_bazel.yml
+  become: yes
+  become_user: "{{ user }}"
+  become_method: su
+  become_flags: "-s /bin/bash"
+
+- name: Build numpy
+  import_tasks: build_numpy.yml
+  become: yes
+  become_user: "{{ user }}"
+  become_method: su
+  become_flags: "-s /bin/bash"
+
+- name: Build tensorflow
+  import_tasks: build_tensorflow.yml
+  become: yes
+  become_user: "{{ user }}"
+  become_method: su
+  become_flags: "-s /bin/bash"
+
+- name: Pre tests
+  import_tasks: pre_test.yml
+  become: yes
+  become_user: "{{ user }}"
+  become_method: su
+  become_flags: "-s /bin/bash"
+
+- name: Test tensorflow
+  import_tasks: test_tensorflow.yml
+  become: yes
+  become_user: "{{ user }}"
+  become_method: su
+  become_flags: "-s /bin/bash"

--- a/files/ansible/roles/tensorflow/tasks/pre_build.yml
+++ b/files/ansible/roles/tensorflow/tasks/pre_build.yml
@@ -1,0 +1,73 @@
+---
+- name: Install dependencies
+  yum:
+          name: "{{ tf_build_dependencies }}"
+          state: latest
+
+- name: Test if OpenHPC is enabled
+  yum:
+          list: "ohpc-release"
+  register: is_ohpc_enabled
+
+- name: Enable OpenHPC if not already done
+  yum:
+          name: "{{ ohpc_release_url }}"
+  when: "'Error: No matching Packages to list' not in is_ohpc_enabled"
+
+- name: Install OpenHPC dependencies
+  yum:
+          name: "{{ tf_build_ohpc_dependencies }}"
+          state: latest
+
+- name: Install Java 8 OpenJDK
+  yum:
+          name: "{{ tf_build_java8 }}"
+          state: latest
+
+- name: Make sure ldconfig knows about ohpc toolchain
+  template:
+          src: ld.so.conf_ohpc.j2
+          dest: /etc/ld.so.conf.d/ohpc.conf
+          owner: root
+          group: root
+          mode: 0644
+
+- name: Make sure ldconfig picks it up
+  shell: "ldconfig -v"
+
+- name: Make sure wheel is NOPASS
+  template:
+          src: sudoers.j2
+          dest: /etc/sudoers
+          validate: "visudo -cf %s"
+          owner: root
+          group: root
+          mode: 0440
+
+- name: Create builder user
+  user:
+          name: builder
+          shell: /bin/bash
+          groups: wheel
+          append: yes
+
+- name: bashrc for builder with lmod
+  template:
+          src: bashrc_builder.j2
+          dest: /home/builder/.bashrc
+          mode: 0644
+          owner: builder
+          group: builder
+
+- name: Create build dirs
+  file:
+          path: "{{ item }}"
+          state: directory
+          mode: '0755'
+          owner: builder
+          group: builder
+  with_items:
+          - "{{ dir_root }}"
+          - "{{ dir_home }}"
+          - "{{ dir_repo }}"
+          - "{{ dir_built }}"

--- a/files/ansible/roles/tensorflow/tasks/pre_build.yml
+++ b/files/ansible/roles/tensorflow/tasks/pre_build.yml
@@ -19,10 +19,16 @@
           name: "{{ tf_build_ohpc_dependencies }}"
           state: latest
 
-- name: Install Java 8 OpenJDK
+- name: Install Java 11 OpenJDK
   yum:
           name: "{{ tf_build_java8 }}"
           state: latest
+
+- name: Put in Java env sourcing
+  template:
+          src: javaenv.sh.j2
+          dest: /etc/profile.d/javaenv.sh
+          mode: 0755 
 
 - name: Make sure ldconfig knows about ohpc toolchain
   template:
@@ -58,6 +64,14 @@
           mode: 0644
           owner: builder
           group: builder
+
+- name: java source paths 
+  template:
+          src: java.sh.j2
+          dest: /etc/profile.d/java.sh
+          mode: 0644
+          owner: root
+          group: root
 
 - name: Create build dirs
   file:

--- a/files/ansible/roles/tensorflow/tasks/pre_build_test.yml
+++ b/files/ansible/roles/tensorflow/tasks/pre_build_test.yml
@@ -1,0 +1,14 @@
+---
+- name: Make sure Lmod is good
+  shell: "ml"
+  args:
+          executable: "/bin/bash"
+  register: ml_log
+- debug: var=ml_log
+   
+- name: Make sure Java and blabla is there
+  shell: "printenv"
+  args:
+          executable: "/bin/bash"
+  register: env_log
+- debug: var=env_log

--- a/files/ansible/roles/tensorflow/tasks/pre_build_venv.yml
+++ b/files/ansible/roles/tensorflow/tasks/pre_build_venv.yml
@@ -1,0 +1,19 @@
+---
+- name: Make sure pip is upgraded
+  pip:
+          name: setuptools
+          executable: pip3
+          extra_args: '--user --upgrade'
+          state: latest
+
+- name: Install python3 dependencies in venv
+  pip:
+          name: "{{ tf_build_py3_dependencies }}"
+          virtualenv: "{{ venv_path }}"
+          virtualenv_command: "{{ python3 }} -m venv"
+          
+- name: Install keras dependencies in venv
+  pip:
+          name: "{{ tf_build_keras }}"
+          virtualenv: "{{ venv_path }}"
+          extra_args: "--no-deps"

--- a/files/ansible/roles/tensorflow/tasks/pre_test.yml
+++ b/files/ansible/roles/tensorflow/tasks/pre_test.yml
@@ -1,0 +1,2 @@
+---
+# Fetch the benchmarks for TF here

--- a/files/ansible/roles/tensorflow/tasks/test_tensorflow.yml
+++ b/files/ansible/roles/tensorflow/tasks/test_tensorflow.yml
@@ -1,0 +1,3 @@
+---
+# Run the benchmarks here
+# Also, might be interesting to run NumPy testsuite/benchmarks

--- a/files/ansible/roles/tensorflow/templates/bashrc_builder.j2
+++ b/files/ansible/roles/tensorflow/templates/bashrc_builder.j2
@@ -7,9 +7,6 @@ fi
 
 sudo ldconfig
 
-ml ohpc
-ml openblas
-ml hdf5
-ml fftw
+ml ohpc openblas hdf5 fftw
 
 export HDF5_DIR="{{ hdf5_base_dir }}"

--- a/files/ansible/roles/tensorflow/templates/bashrc_builder.j2
+++ b/files/ansible/roles/tensorflow/templates/bashrc_builder.j2
@@ -1,0 +1,15 @@
+# .bashrc
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+	. /etc/bashrc
+fi
+
+sudo ldconfig
+
+ml ohpc
+ml openblas
+ml hdf5
+ml fftw
+
+export HDF5_DIR="{{ hdf5_base_dir }}"

--- a/files/ansible/roles/tensorflow/templates/bazel.repo.j2
+++ b/files/ansible/roles/tensorflow/templates/bazel.repo.j2
@@ -1,0 +1,5 @@
+[bazel_repo]
+name=BazelRepo
+baseurl=http://10.40.0.13/repo/bazel
+enabled=1
+gpgcheck=0

--- a/files/ansible/roles/tensorflow/templates/bazel.spec.j2
+++ b/files/ansible/roles/tensorflow/templates/bazel.spec.j2
@@ -1,0 +1,261 @@
+%define _disable_source_fetch 0
+
+Name:           bazel
+Version:        0.26.1
+Release:        0%{?dist}
+Summary:        Correct, reproducible, and fast builds for everyone.
+License:        Apache License 2.0
+URL:            http://bazel.io/
+Source0:        https://github.com/bazelbuild/bazel/releases/download/%{version}/%{name}-%{version}-dist.zip
+
+BuildRequires:  java-11-openjdk-devel
+BuildRequires:  zlib-devel
+BuildRequires:  pkgconfig
+BuildRequires:  findutils
+BuildRequires:  gcc-c++
+BuildRequires:  which
+BuildRequires:  zip
+AutoReq: no
+
+# only for centos7/rhel7. rhel8 has `python3`.
+%if 0%{?rhel} > 6 && 0%{?rhel} < 8
+BuildRequires:  epel-release
+BuildRequires:  python36
+%else
+BuildRequires:  python3
+%endif
+
+Requires:       java-11-openjdk-devel
+
+%define bashcompdir %(pkg-config --variable=completionsdir bash-completion 2>/dev/null)
+%global debug_package %{nil}
+%define __os_install_post %{nil}
+
+%description
+Correct, reproducible, and fast builds for everyone.
+
+%prep
+%setup -q -c -n %{name}-%{version}
+
+%build
+# thanks to @aehlig for this tip: https://github.com/bazelbuild/bazel/issues/8665#issuecomment-503575270
+find . -type f -regextype posix-extended -iregex '.*(sh|txt|py|_stub|stub_.*|bazel|get_workspace_status|protobuf_support|_so)' -exec %{__sed} -i -e '1s|^#!/usr/bin/env python$|#!/usr/bin/env python3|' "{}" \;
+export EXTRA_BAZEL_ARGS="${EXTRA_BAZEL_ARGS} --python_path=/usr/bin/python3"
+
+# horrible of horribles, just to have `python` in the PATH
+# https://github.com/bazelbuild/bazel/issues/8665
+%{__mkdir_p} ./bin-hack
+%{__ln_s} /usr/bin/python3 ./bin-hack/python
+export PATH=$(pwd)/bin-hack:$PATH
+
+# bger: To be investigated
+%ifarch aarch64
+export EXTRA_BAZEL_ARGS="${EXTRA_BAZEL_ARGS} --nokeep_state_after_build --notrack_incremental_state --nokeep_state_after_build --sandbox_debug"
+%else
+%endif
+
+# loose epoch from their release date
+export SOURCE_DATE_EPOCH="$(date -d $(head -1 CHANGELOG.md | %{__grep} -Eo '\b[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}\b' ) +%s)"
+export EMBED_LABEL="%{version}"
+
+export CC=gcc
+export CXX=g++
+export EXTRA_BAZEL_ARGS="${EXTRA_BAZEL_ARGS} --host_javabase=@local_jdk//:jdk --javabase=@local_jdk//:jdk --verbose_failures"
+./compile.sh ${EXTRA_BAZEL_ARGS}
+./output/bazel shutdown
+
+%install
+%{__mkdir_p} %{buildroot}/%{_bindir}
+%{__mkdir_p} %{buildroot}/%{bashcompdir}
+%{__cp} output/bazel %{buildroot}/%{_bindir}/bazel-real
+%{__cp} ./scripts/packages/bazel.sh %{buildroot}/%{_bindir}/bazel
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root)
+%attr(0755,root,root) %{_bindir}/bazel
+%attr(0755,root,root) %{_bindir}/bazel-real
+
+
+%changelog
+* Wed Nov 06 2019 Baptiste Gerondeau <baptiste.gerondeau@linaro.org> 0.24.1-1
+- remove bash-completion failing target 
+
+* Wed Oct 30 2019 Baptiste Gerondeau <baptiste.gerondeau@linaro.org> 0.24.1-1
+- downgrade to 0.24.1 and python36 for CentOS7 via EPEL
+
+* Fri Jul 19 2019 Vincent Batts <vbatts@fedoraproject.org> 0.28.1-0
+- update to 0.28.1
+
+* Fri Jul 19 2019 Vincent Batts <vbatts@fedoraproject.org> 0.28.0-0
+- update to 0.28.0
+
+* Thu Jul 11 2019 Vincent Batts <vbatts@fedoraproject.org> 0.27.2-0
+- update to 0.27.2
+
+* Thu Jul 04 2019 Vincent Batts <vbatts@fedoraproject.org> 0.27.1-0
+- update to 0.27.1
+
+* Fri Jun 21 2019 Vincent Batts <vbatts@fedoraproject.org> 0.27.0-7
+- carry patch for grpc fix due to newest glibc
+
+* Thu Jun 20 2019 Kelvin Lu <kelvinlu@squareup.com> 0.27.0-6
+- rename the real bazel binary as `bazel-real` and install the bash wrapper
+  (`scripts/packages/bazel.sh`) in its place
+
+* Thu Jun 20 2019 Vincent Batts <vbatts@fedoraproject.org> 0.27.0-5
+- fixing the version output
+
+* Wed Jun 19 2019 Vincent Batts <vbatts@fedoraproject.org> 0.27.0-4
+- python3 workaround again, but for rhel8-beta as well
+
+* Tue Jun 18 2019 Vincent Batts <vbatts@fedoraproject.org> 0.27.0-3
+- python3 workaround for fedora's
+
+* Mon Jun 17 2019 Vincent Batts <vbatts@fedoraproject.org> 0.27.0-2
+- python3 everywhere
+
+* Mon Jun 17 2019 Vincent Batts <vbatts@fedoraproject.org> 0.27.0-1
+- update to 0.27.0
+
+* Tue Jun 11 2019 Vincent Batts <vbatts@fedoraproject.org> 0.26.0-2
+- update to 0.26.0
+
+* Fri May 24 2019 Vincent Batts <vbatts@fedoraproject.org> 0.25.3-2
+- trying aarch64 specific flags
+
+* Fri May 24 2019 Vincent Batts <vbatts@fedoraproject.org> 0.25.3-1
+- update to 0.25.3
+
+* Mon May 13 2019 Vincent Batts <vbatts@fedoraproject.org> 0.25.2-1
+- update to 0.25.2
+
+* Mon May 13 2019 Vincent Batts <vbatts@fedoraproject.org> 0.25.1-1
+- update to 0.25.1
+
+* Mon May 13 2019 Vincent Batts <vbatts@fedoraproject.org> 0.25.0-3
+- less janky use of python3
+
+* Wed May 08 2019 Vincent Batts <vbatts@fedoraproject.org> 0.25.0-2
+- actually use host jdk
+- bazel didn't fully compile with openjdk 1.8.0, updated to 11
+
+* Thu May 02 2019 Vincent Batts <vbatts@fedoraproject.org> 0.25.0-1
+- update to 0.25.0
+- https://github.com/bazelbuild/bazel/releases/tag/0.25.0
+
+* Tue Apr 02 2019 Vincent Batts <vbatts@fedoraproject.org> 0.24.2-1
+- update to 0.24.1
+
+* Tue Mar 26 2019 Vincent Batts <vbatts@fedoraproject.org> 0.24.0-1
+- update to 0.24.0
+
+* Mon Mar 11 2019 Vincent Batts <vbatts@fedoraproject.org> 0.23.2-1
+- update to 0.23.2
+
+* Mon Mar 04 2019 Vincent Batts <vbatts@fedoraproject.org> 0.23.1-1
+- update to 0.23.1
+
+* Tue Feb 26 2019 Vincent Batts <vbatts@fedoraproject.org> 0.23.0-1
+- update to 0.23.0
+
+* Tue Jan 29 2019 Vincent Batts <vbatts@fedoraproject.org> 0.22.0-1
+- update to 0.22.0
+
+* Wed Dec 19 2018 Vincent Batts <vbatts@fedoraproject.org> 0.21.0-1
+- update to 0.21.0
+
+* Mon Nov 19 2018 Vincent Batts <vbatts@fedoraproject.org> 0.19.2-1
+- update to 0.19.2
+
+* Mon Nov 12 2018 Vincent Batts <vbatts@fedoraproject.org> 0.19.1-1
+- update to 0.19.1
+
+* Tue Oct 30 2018 Vincent Batts <vbatts@fedoraproject.org> 0.19.0-2
+- addressing https://github.com/bazelbuild/bazel/issues/6550
+
+* Mon Oct 29 2018 Vincent Batts <vbatts@fedoraproject.org> 0.19.0-1
+- update to 0.19.0
+
+* Mon Oct 15 2018 Vincent Batts <vbatts@fedoraproject.org> 0.18.0-1
+- update to 0.18.0
+
+* Fri Sep 21 2018 Vincent Batts <vbatts@fedoraproject.org> 0.17.2-1
+- update to 0.17.2
+
+* Fri Sep 14 2018 Vincent Batts <vbatts@fedoraproject.org> 0.17.1-1
+- update to 0.17.1
+
+* Mon Aug 13 2018 Vincent Batts <vbatts@fedoraproject.org> 0.16.1-1
+- update to 0.16.1
+
+* Tue Jul 31 2018 Vincent Batts <vbatts@fedoraproject.org> 0.16.0-1
+- update to 0.16.0
+
+* Tue Jul 17 2018 Vincent Batts <vbatts@fedoraproject.org> 0.15.2-1
+- update to 0.15.2
+
+* Mon Jul 16 2018 Vincent Batts <vbatts@fedoraproject.org> 0.15.1-1
+- update to 0.15.1
+
+* Wed Jun 27 2018 Vincent Batts <vbatts@fedoraproject.org> 0.15.0-2
+- add back the symbols (don't strip) as there is a binary embedded in the binary! :-O
+
+* Tue Jun 26 2018 Vincent Batts <vbatts@fedoraproject.org> 0.15.0-1
+- update to 0.15.0
+
+* Fri Jun 22 2018 Vincent Batts <vbatts@fedoraproject.org> 0.14.1-2
+- stripping the binary. 100.5Mb -> 1.5Mb. Could not isolate out the debuginfo
+  into its own linked debuginfo package. Not sture whats going on there. But
+  for now just stripping unneeded.
+
+* Fri Jun 08 2018 Vincent Batts <vbatts@fedoraproject.org> 0.14.1-1
+- update to 0.14.1
+
+* Fri Jun 01 2018 Vincent Batts <vbatts@fedoraproject.org> 0.14.0-1
+- update to 0.14.0
+
+* Wed May 23 2018 Vincent Batts <vbatts@fedoraproject.org> 0.13.1-1
+- update to 0.13.1
+
+* Mon Apr 30 2018 Vincent Batts <vbatts@fedoraproject.org> 0.13.0-1
+- update to 0.13.0
+
+* Fri Apr 13 2018 Vincent Batts <vbatts@fedoraproject.org> 0.12.0-1
+- update to 0.12.0
+
+* Thu Feb 22 2018 Vincent Batts <vbatts@fedoraproject.org> 0.10.1-1
+- update to 0.10.1
+
+* Thu Feb 01 2018 Vincent Batts <vbatts@fedoraproject.org> 0.10.0-1
+- update to 0.10.0
+
+* Tue Jan 16 2018 Vincent Batts <vbatts@fedoraproject.org> 0.9.0-1
+- update to 0.9.0
+
+* Thu Nov 30 2017 Vincent Batts <vbatts@fedoraproject.org> 0.8.0-1
+- update to 0.8.0
+
+* Wed Oct 18 2017 Vincent Batts <vbatts@fedoraproject.org> 0.7.0-1
+- update to 0.7.0
+
+* Thu Sep 28 2017 Vincent Batts <vbatts@fedoraproject.org> 0.6.0-1
+- update to 0.6.0
+
+* Fri Aug 25 2017 Vincent Batts <vbatts@fedoraproject.org> 0.5.4-1
+- adding missing builddeps
+
+* Fri Aug 25 2017 Vincent Batts <vbatts@fedoraproject.org> 0.5.4-0
+- update from upstream
+- and spec cleanup for webhook builds
+
+* Wed Aug 02 2017 Vincent Batts <vbatts@fedoraproject.org> 0.5.3-0
+- update from upstream
+
+* Wed Dec 21 2016 Byoungchan Lee <byoungchan.lee@gmx.com> 0.4.2-0
+- update from upstream release
+
+* Sun Dec 11 2016 Byoungchan Lee <byoungchan.lee@gmx.com> 0.3.2-0
+- initial spec file

--- a/files/ansible/roles/tensorflow/templates/build_tensorflow.sh.j2
+++ b/files/ansible/roles/tensorflow/templates/build_tensorflow.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+source {{ venv_path }}/bin/activate
+bazel build --config=opt {% for tf_cxxopt in tensorflow.cxx_optimizations %} --cxxopt={{ tf_cxxopt | quote }} {% endfor %} {% for tf_copt in tensorflow.c_optimizations %} --copt={{ tf_copt | quote }} {% endfor %} --verbose_failures tensorflow/tools/pip_package:build_pip_package

--- a/files/ansible/roles/tensorflow/templates/configure_tensorflow.sh.j2
+++ b/files/ansible/roles/tensorflow/templates/configure_tensorflow.sh.j2
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+  export PYTHON_BIN_PATH="{{ venv_path }}/bin/python3"
+  export PYTHON_LIB_PATH="{{ venv_path }}/lib/python3.6/site-packages/"
+
+  export TF_NEED_GCP=0
+  export TF_NEED_CUDA=0
+  export TF_NEED_HDFS=0
+  export TF_NEED_OPENCL=0
+  export TF_NEED_JEMALLOC=1
+  export TF_ENABLE_XLA=0
+  export TF_NEED_VERBS=0
+  export TF_CUDA_CLANG=0
+  export TF_NEED_MKL=0
+  export TF_DOWNLOAD_MKL=0
+  export TF_NEED_AWS=0
+  export TF_NEED_MPI=0
+  export TF_NEED_GDR=0
+  export TF_NEED_S3=0
+  export TF_NEED_OPENCL_SYCL=0
+  export TF_SET_ANDROID_WORKSPACE=0
+  export TF_NEED_COMPUTECPP=0
+  #export TF_SET_ANDROID_WORKSPACE=0
+  export TF_NEED_KAFKA=0
+  export TF_NEED_TENSORRT=0
+  export TF_NEED_ROCM=0
+  export TF_DOWNLOAD_CLANG=0
+
+  # when using NCCL you need to install it own your own
+  export GCC_HOST_COMPILER_PATH="{{ ohpc_toolchain_base_dir }}/bin/gcc"
+  export HOST_C_COMPILER=$GCC_HOST_COMPILER_PATH
+  export PREFIX="{{ ohpc_toolchain_base_dir }}"
+  export CC_OPT_FLAGS="-march=native"
+
+source {{ venv_path }}/bin/activate && {{ tensorflow_configure }}

--- a/files/ansible/roles/tensorflow/templates/java.sh.j2
+++ b/files/ansible/roles/tensorflow/templates/java.sh.j2
@@ -1,0 +1,3 @@
+export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
+export PATH=$PATH:$JAVA_HOME/bin
+export CLASSPATH=.:$JAVA_HOME/jre/lib:$JAVA_HOME/lib:$JAVA_HOME/lib/tools.jar

--- a/files/ansible/roles/tensorflow/templates/java8.sh.j2
+++ b/files/ansible/roles/tensorflow/templates/java8.sh.j2
@@ -1,0 +1,3 @@
+export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
+export PATH=\$PATH:\$JAVA_HOME/bin
+export CLASSPATH=.:\$JAVA_HOME/jre/lib:\$JAVA_HOME/lib:\$JAVA_HOME/lib/tools.jar

--- a/files/ansible/roles/tensorflow/templates/java8.sh.j2
+++ b/files/ansible/roles/tensorflow/templates/java8.sh.j2
@@ -1,3 +1,0 @@
-export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
-export PATH=\$PATH:\$JAVA_HOME/bin
-export CLASSPATH=.:\$JAVA_HOME/jre/lib:\$JAVA_HOME/lib:\$JAVA_HOME/lib/tools.jar

--- a/files/ansible/roles/tensorflow/templates/javaenv.sh.j2
+++ b/files/ansible/roles/tensorflow/templates/javaenv.sh.j2
@@ -1,0 +1,3 @@
+export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which javac)))))
+export PATH=$PATH:$JAVA_HOME/bin
+export CLASSPATH=.:$JAVA_HOME/jre/lib:$JAVA_HOME/lib:$JAVA_HOME/lib/tools.jar

--- a/files/ansible/roles/tensorflow/templates/ld.so.conf_ohpc.j2
+++ b/files/ansible/roles/tensorflow/templates/ld.so.conf_ohpc.j2
@@ -1,0 +1,1 @@
+{{ ohpc_toolchain_lib_dir }}

--- a/files/ansible/roles/tensorflow/templates/numpy-site.cfg.j2
+++ b/files/ansible/roles/tensorflow/templates/numpy-site.cfg.j2
@@ -1,0 +1,155 @@
+# This file provides configuration information about non-Python dependencies for
+# numpy.distutils-using packages. Create a file like this called "site.cfg" next
+# to your package's setup.py file and fill in the appropriate sections. Not all
+# packages will use all sections so you should leave out sections that your
+# package does not use.
+
+# To assist automatic installation like pip, the user's home directory
+# will also be checked for the file ~/.numpy-site.cfg .
+
+# The format of the file is that of the standard library's ConfigParser module.
+# No interpolation is allowed; the RawConfigParser class is being used to load it.
+#
+#   https://docs.python.org/library/configparser.html
+#
+# Each section defines settings that apply to one particular dependency. Some of
+# the settings are general and apply to nearly any section and are defined here.
+# Settings specific to a particular section will be defined near their section.
+#
+#   libraries
+#       Comma-separated list of library names to add to compile the extension
+#       with. Note that these should be just the names, not the filenames. For
+#       example, the file "libfoo.so" would become simply "foo".
+#           libraries = lapack,f77blas,cblas,atlas
+#       This setting is available for *all* sections.
+#
+#   library_dirs
+#       List of directories to add to the library search path when compiling
+#       extensions with this dependency. Use the character given by os.pathsep
+#       to separate the items in the list. Note that this character is known to
+#       vary on some unix-like systems; if a colon does not work, try a comma.
+#       This also applies to include_dirs and src_dirs (see below).
+#       On UN*X-type systems (OS X, most BSD and Linux systems):
+#           library_dirs = /usr/lib:/usr/local/lib
+#       On Windows:
+#           library_dirs = c:\mingw\lib,c:\atlas\lib
+#       On some BSD and Linux systems:
+#           library_dirs = /usr/lib,/usr/local/lib
+#
+#   include_dirs
+#       List of directories to add to the header file search path.
+#           include_dirs = /usr/include:/usr/local/include
+#
+#   src_dirs 
+#       List of directories that contain extracted source code for the
+#       dependency. For some dependencies, numpy.distutils will be able to build
+#       them from source if binaries cannot be found. The FORTRAN BLAS and
+#       LAPACK libraries are one example. However, most dependencies are more
+#       complicated and require actual installation that you need to do
+#       yourself.
+#           src_dirs = /home/username/src/BLAS_SRC:/home/username/src/LAPACK_SRC
+#
+#   search_static_first
+#       Boolean (one of (0, false, no, off) for False or (1, true, yes, on) for
+#       True) to tell numpy.distutils to prefer static libraries (.a) over
+#       shared libraries (.so). It is turned off by default.
+#           search_static_first = false
+#
+#   runtime_library_dirs/rpath
+#       List of directories that contains the libraries that should be 
+#       used at runtime, thereby disregarding the LD_LIBRARY_PATH variable.
+#       See 'library_dirs' for formatting on different platforms.
+#           runtime_library_dirs = /opt/blas/lib:/opt/lapack/lib
+#       or equivalently
+#           rpath = /opt/blas/lib:/opt/lapack/lib
+#
+#   extra_compile_args
+#       Add additional arguments to the compilation of sources.
+#       Split into arguments in a platform-appropriate way.
+#       Provide a single line with all complete flags.
+#           extra_compile_args = -g -ftree-vectorize
+#
+#   extra_link_args
+#       Add additional arguments when libraries/executables
+#       are linked.
+#       Split into arguments in a platform-appropriate way.
+#       Provide a single line with all complete flags.
+#           extra_link_args = -lgfortran
+#
+
+# Defaults
+# ========
+# The settings given here will apply to all other sections if not overridden.
+# This is a good place to add general library and include directories like
+# /usr/local/{lib,include}
+#
+[ALL]
+library_dirs = "{{ LD_LIBRARY_PATH }}"
+include_dirs = "{{ LD_INCLUDE_PATH }}"
+#
+
+# OpenBLAS
+# --------
+# OpenBLAS is another open source optimized implementation of BLAS and LAPACK
+# and can be seen as an alternative to ATLAS. To build NumPy against OpenBLAS
+# instead of ATLAS, use this section instead of the above, adjusting as needed
+# for your configuration (in the following example we installed OpenBLAS with
+# ``make install PREFIX=/opt/OpenBLAS``.
+# OpenBLAS is generically installed as a shared library, to force the OpenBLAS
+# library linked to also be used at runtime you can utilize the 
+# runtime_library_dirs variable.
+#
+# **Warning**: OpenBLAS, by default, is built in multithreaded mode. Due to the
+# way Python's multiprocessing is implemented, a multithreaded OpenBLAS can
+# cause programs using both to hang as soon as a worker process is forked on
+# POSIX systems (Linux, Mac).
+# This is fixed in OpenBLAS 0.2.9 for the pthread build, the OpenMP build using
+# GNU openmp is as of gcc-4.9 not fixed yet.
+# Python 3.4 will introduce a new feature in multiprocessing, called the
+# "forkserver", which solves this problem. For older versions, make sure
+# OpenBLAS is built using pthreads or use Python threads instead of
+# multiprocessing.
+# (This problem does not exist with multithreaded ATLAS.)
+#
+# https://docs.python.org/library/multiprocessing.html#contexts-and-start-methods
+# https://github.com/xianyi/OpenBLAS/issues/294
+#
+[openblas]
+libraries = openblas
+library_dirs = "{{ openblas_library_path }}" 
+include_dirs = "{{ openblas_include_path }}"
+runtime_library_dirs = "{{ openblas_library_path }}"
+
+# UMFPACK
+# -------
+# The UMFPACK library is used in scikits.umfpack to factor large sparse matrices. 
+# It, in turn, depends on the AMD library for reordering the matrices for
+# better performance.  Note that the AMD library has nothing to do with AMD
+# (Advanced Micro Devices), the CPU company.
+#
+# UMFPACK is not used by NumPy.
+#
+#   https://www.cise.ufl.edu/research/sparse/umfpack/
+#   https://www.cise.ufl.edu/research/sparse/amd/
+#   https://scikit-umfpack.github.io/scikit-umfpack/
+#
+#[amd]
+#libraries = amd
+#
+#[umfpack]
+#libraries = umfpack
+
+# FFT libraries
+# -------------
+# There are two FFT libraries that we can configure here: FFTW (2 and 3) and djbfft.
+# Note that these libraries are not used by NumPy or SciPy.
+#
+#   http://fftw.org/
+#   https://cr.yp.to/djbfft.html
+#
+# Given only this section, numpy.distutils will try to figure out which version
+# of FFTW you are using.
+[fftw]
+libraries = fftw3
+library_dirs = "{{ fftw_library_path }}" 
+include_dirs = "{{ fftw_include_path }}"

--- a/files/ansible/roles/tensorflow/templates/numpy_centos7_aarch64.patch.j2
+++ b/files/ansible/roles/tensorflow/templates/numpy_centos7_aarch64.patch.j2
@@ -1,3 +1,4 @@
+{% if numpy_version in ['1.17.3', '1.17.4'] %}
 --- numpy/core/src/npymath/npy_math_complex.c.src.orig	2019-10-07 14:22:00.073904595 +0100
 +++ numpy/core/src/npymath/npy_math_complex.c.src	2019-10-07 14:22:11.185036951 +0100
 @@ -1385,7 +1385,7 @@
@@ -9,3 +10,16 @@
  npy_cacosh@c@(@ctype@ z)
  {
      /*
+{% elif numpy_version in ['1.17.4'] %}
+--- numpy/core/src/npymath/npy_math_internal.h.src.orig	2019-11-14 12:20:01.387180922 +0000
++++ numpy/core/src/npymath/npy_math_internal.h.src	2019-11-14 12:19:17.960646234 +0000
+@@ -477,7 +477,7 @@
+  * #KIND = ATAN2,HYPOT,POW,FMOD,COPYSIGN#
+  */
+ #ifdef HAVE_@KIND@@C@
+-NPY_INPLACE @type@ npy_@kind@@c@(@type@ x, @type@ y)
++NPY_INPLACE __attribute__((optimize("-O0"))) @type@ npy_@kind@@c@(@type@ x, @type@ y)
+ {
+     return @kind@@c@(x, y);
+ }
+{% endif %}

--- a/files/ansible/roles/tensorflow/templates/numpy_centos7_aarch64.patch.j2
+++ b/files/ansible/roles/tensorflow/templates/numpy_centos7_aarch64.patch.j2
@@ -1,0 +1,11 @@
+--- numpy/core/src/npymath/npy_math_complex.c.src.orig	2019-10-07 14:22:00.073904595 +0100
++++ numpy/core/src/npymath/npy_math_complex.c.src	2019-10-07 14:22:11.185036951 +0100
+@@ -1385,7 +1385,7 @@
+ #endif
+ 
+ #ifndef HAVE_CACOSH@C@
+-@ctype@
++@ctype@ __attribute__((optimize("-O0")))
+ npy_cacosh@c@(@ctype@ z)
+ {
+     /*

--- a/files/ansible/roles/tensorflow/templates/patch_bazelbuild.patch.j2
+++ b/files/ansible/roles/tensorflow/templates/patch_bazelbuild.patch.j2
@@ -1,0 +1,64 @@
+--- WORKSPACE.orig	2019-10-08 01:04:53.956098481 +0100
++++ WORKSPACE	2019-10-08 01:06:35.366491612 +0100
+@@ -1,5 +1,60 @@
+ workspace(name = "org_tensorflow")
+ 
++load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++
++# Download the rules_docker repository at release v0.11.0
++http_archive(
++    name = "io_bazel_rules_docker",
++    sha256 = "480daa8737bf4370c1a05bfced903827e75046fea3123bd8c81389923d968f55",
++    strip_prefix = "rules_docker-0.11.0",
++    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.11.0/rules_docker-v0.11.0.tar.gz"],
++)
++
++# OPTIONAL: Call this to override the default docker toolchain configuration.
++# This call should be placed BEFORE the call to "container_repositories" below
++# to actually override the default toolchain configuration.
++# Note this is only required if you actually want to call
++# docker_toolchain_configure with a custom attr; please read the toolchains
++# docs in /toolchains/docker/ before blindly adding this to your WORKSPACE.
++# BEGIN OPTIONAL segment:
++load("@io_bazel_rules_docker//toolchains/docker:toolchain.bzl",
++    docker_toolchain_configure="toolchain_configure"
++)
++docker_toolchain_configure(
++  name = "docker_config",
++  # OPTIONAL: Path to a directory which has a custom docker client config.json.
++  # See https://docs.docker.com/engine/reference/commandline/cli/#configuration-files
++  # for more details.
++  client_config="<enter absolute path to your docker config directory here>",
++)
++# End of OPTIONAL segment.
++
++load(
++    "@io_bazel_rules_docker//repositories:repositories.bzl",
++    container_repositories = "repositories",
++)
++container_repositories()
++
++# This is NOT needed when going through the language lang_image
++# "repositories" function(s).
++load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
++
++container_deps()
++
++load(
++    "@io_bazel_rules_docker//container:container.bzl",
++    "container_pull",
++)
++
++container_pull(
++  name = "java_base",
++  registry = "gcr.io",
++  repository = "distroless/java",
++  # 'tag' is also supported, but digest is encouraged for reproducibility.
++  digest = "sha256:deadbeef",
++)
++
++
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+ 
+ http_archive(
+

--- a/files/ansible/roles/tensorflow/templates/sudoers.j2
+++ b/files/ansible/roles/tensorflow/templates/sudoers.j2
@@ -1,0 +1,120 @@
+## Sudoers allows particular users to run various commands as
+## the root user, without needing the root password.
+##
+## Examples are provided at the bottom of the file for collections
+## of related commands, which can then be delegated out to particular
+## users or groups.
+## 
+## This file must be edited with the 'visudo' command.
+
+## Host Aliases
+## Groups of machines. You may prefer to use hostnames (perhaps using 
+## wildcards for entire domains) or IP addresses instead.
+# Host_Alias     FILESERVERS = fs1, fs2
+# Host_Alias     MAILSERVERS = smtp, smtp2
+
+## User Aliases
+## These aren't often necessary, as you can use regular groups
+## (ie, from files, LDAP, NIS, etc) in this file - just use %groupname 
+## rather than USERALIAS
+# User_Alias ADMINS = jsmith, mikem
+
+
+## Command Aliases
+## These are groups of related commands...
+
+## Networking
+# Cmnd_Alias NETWORKING = /sbin/route, /sbin/ifconfig, /bin/ping, /sbin/dhclient, /usr/bin/net, /sbin/iptables, /usr/bin/rfcomm, /usr/bin/wvdial, /sbin/iwconfig, /sbin/mii-tool
+
+## Installation and management of software
+# Cmnd_Alias SOFTWARE = /bin/rpm, /usr/bin/up2date, /usr/bin/yum
+
+## Services
+# Cmnd_Alias SERVICES = /sbin/service, /sbin/chkconfig, /usr/bin/systemctl start, /usr/bin/systemctl stop, /usr/bin/systemctl reload, /usr/bin/systemctl restart, /usr/bin/systemctl status, /usr/bin/systemctl enable, /usr/bin/systemctl disable
+
+## Updating the locate database
+# Cmnd_Alias LOCATE = /usr/bin/updatedb
+
+## Storage
+# Cmnd_Alias STORAGE = /sbin/fdisk, /sbin/sfdisk, /sbin/parted, /sbin/partprobe, /bin/mount, /bin/umount
+
+## Delegating permissions
+# Cmnd_Alias DELEGATING = /usr/sbin/visudo, /bin/chown, /bin/chmod, /bin/chgrp 
+
+## Processes
+# Cmnd_Alias PROCESSES = /bin/nice, /bin/kill, /usr/bin/kill, /usr/bin/killall
+
+## Drivers
+# Cmnd_Alias DRIVERS = /sbin/modprobe
+
+# Defaults specification
+
+#
+# Refuse to run if unable to disable echo on the tty.
+#
+Defaults   !visiblepw
+
+#
+# Preserving HOME has security implications since many programs
+# use it when searching for configuration files. Note that HOME
+# is already set when the the env_reset option is enabled, so
+# this option is only effective for configurations where either
+# env_reset is disabled or HOME is present in the env_keep list.
+#
+Defaults    always_set_home
+Defaults    match_group_by_gid
+
+# Prior to version 1.8.15, groups listed in sudoers that were not
+# found in the system group database were passed to the group
+# plugin, if any. Starting with 1.8.15, only groups of the form
+# %:group are resolved via the group plugin by default.
+# We enable always_query_group_plugin to restore old behavior.
+# Disable this option for new behavior.
+Defaults    always_query_group_plugin
+
+Defaults    env_reset
+Defaults    env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS"
+Defaults    env_keep += "MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE"
+Defaults    env_keep += "LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES"
+Defaults    env_keep += "LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE"
+Defaults    env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY"
+
+#
+# Adding HOME to env_keep may enable a user to run unrestricted
+# commands via sudo.
+#
+# Defaults   env_keep += "HOME"
+
+Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+
+## Next comes the main part: which users can run what software on 
+## which machines (the sudoers file can be shared between multiple
+## systems).
+## Syntax:
+##
+## 	user	MACHINE=COMMANDS
+##
+## The COMMANDS section may have other options added to it.
+##
+## Allow root to run any commands anywhere 
+root	ALL=(ALL) 	ALL
+
+## Allows members of the 'sys' group to run networking, software, 
+## service management apps and more.
+# %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
+
+## Allows people in group wheel to run all commands
+#%wheel	ALL=(ALL)	ALL
+
+## Same thing without a password
+%wheel	ALL=(ALL)	NOPASSWD: ALL
+
+## Allows members of the users group to mount and unmount the 
+## cdrom as root
+# %users  ALL=/sbin/mount /mnt/cdrom, /sbin/umount /mnt/cdrom
+
+## Allows members of the users group to shutdown this system
+# %users  localhost=/sbin/shutdown -h now
+
+## Read drop-in files from /etc/sudoers.d (the # here does not mean a comment)
+#includedir /etc/sudoers.d

--- a/files/build_tensorflow.yml
+++ b/files/build_tensorflow.yml
@@ -102,5 +102,6 @@
                         build_id: ${BUILD_NUMBER}
                         EOF
 
+                        ANSIBLE_CONFIG="${WORKSPACE}/hpc_lab_setup/files/ansible/ansible.cfg" ansible-playbook -v "${WORKSPACE}/hpc_lab_setup/files/ansible/install_python3.yml" -i "${WORKSPACE}/hosts"
                         ANSIBLE_CONFIG="${WORKSPACE}/hpc_lab_setup/files/ansible/ansible.cfg" ansible-playbook -v "${WORKSPACE}/hpc_lab_setup/files/ansible/build_tensorflow.yml" -i "${WORKSPACE}/hosts"  --extra-vars="@${WORKSPACE}/tensorflow_build.yml"
                         ssh-agent -k 

--- a/files/build_tensorflow.yml
+++ b/files/build_tensorflow.yml
@@ -1,0 +1,106 @@
+ - job:
+         name: build_tensorflow
+         description: "This is a job to build Tensorflow on a machine"
+         project-type: freestyle
+         block-downstream: false
+         concurrent: true
+         node: "xecutor"
+         properties:
+                 - authorization:
+                         hpc-sig-admin:
+                                 - credentials-create
+                                 - credentials-delete
+                                 - credentials-manage-domains
+                                 - credentials-update
+                                 - credentials-view
+                                 - job-build
+                                 - job-cancel
+                                 - job-configure
+                                 - job-delete
+                                 - job-discover
+                                 - job-move
+                                 - job-read
+                                 - job-status
+                                 - job-workspace
+                                 - ownership-jobs
+                                 - run-delete
+                                 - run-update
+                                 - scm-tag
+                         hpc-sig-devel:
+                                 - job-build
+         parameters:
+                 - node:
+                         name: node
+                         allowed-slaves:
+                                 - qdf01
+                                 - d03bench
+                                 - d05bench
+                                 - qdfbench
+                                 - tx2bench
+                                 - x86bench
+                         allowed-multiselect: true
+                         ignore-offline-nodes: true
+                         description: 'Node with which to run the benchmark on the machine'
+                 - string:
+                         name: automation_branch
+                         default: 'master'
+                         description: 'The Ansible logic branch to use'
+         builders:
+                 - shell: |
+                        #!/bin/bash
+                        set -ex
+                        cd ${WORKSPACE}
+                        eval `ssh-agent`
+                        ssh-add
+
+                        case ${node} in
+                        d03*)
+                            vendor='huawei'
+                            node_type=d03
+                            machine_type=aarch64
+                            ;;
+                        d05*)
+                            vendor='huawei'
+                            node_type=d05
+                            machine_type=aarch64
+                            ;;
+                        qdf*)
+                            vendor='qualcomm'
+                            node_type=qdf
+                            machine_type=aarch64
+                            ;;
+                        tx*)
+                            vendor='cavium'
+                            node_type=tx2
+                            machine_type=aarch64
+                            ;;
+                        x86*)
+                            vendor='intel'
+                            node_type=x86
+                            machine_type=x86_64
+                            ;;
+                        esac
+
+                        if [ -d "${WORKSPACE}/hpc_lab_setup" ]; then
+                            rm -rf "${WORKSPACE}/hpc_lab_setup"
+                        fi
+                        git clone -b ${automation_branch} https://github.com/Linaro/hpc_lab_setup.git "${WORKSPACE}/hpc_lab_setup"
+
+                        if [ -d "${WORKSPACE}/mr-provisioner-client" ]; then
+                            rm -rf "${WORKSPACE}/mr-provisioner-client"
+                        fi
+                        git clone https://github.com/Linaro/mr-provisioner-client.git "${WORKSPACE}/mr-provisioner-client"
+
+                        machine_ip=$( "${WORKSPACE}/mr-provisioner-client/mrp_client.py" --mrp-token=$(cat "/home/${NODE_NAME}/mrp_token") --mrp-url="http://10.40.0.11:5000" net --action getip --machine "${node_type}bench" --interface eth1)
+
+                        cat << EOF > "${WORKSPACE}/hosts"
+                        [target]
+                        ${machine_ip} ansible_user=root
+                        EOF
+
+                        cat << EOF > tensorflow_build.yml
+                        build_id: ${BUILD_NUMBER}
+                        EOF
+
+                        ANSIBLE_CONFIG="${WORKSPACE}/hpc_lab_setup/files/ansible/ansible.cfg" ansible-playbook -v "${WORKSPACE}/hpc_lab_setup/files/ansible/build_tensorflow.yml" -i "${WORKSPACE}/hosts"  --extra-vars="@${WORKSPACE}/tensorflow_build.yml"
+                        ssh-agent -k 


### PR DESCRIPTION
This commit adds a role to build Tensorflow with the following
stack:
 - NumPy is built by the role (and hooked up to OpenBLAS and FFTW)
 - TensorFlow is built by the role
 - Bazel, a Java tool to build Tensorflow is built by the role
 - OpenBLAS, FFTW, GCC and HDF5 are provided by OpenHPC
 - SciPy, keras, h5py and other python deps are fetched by pip

This role currently only supports CentOS7
Performance might benefit from building OpenBLAS, FFTW and SciPy.
Also, microarchitecture specific compiler flags might be interesting