### PR TITLE
Preseeds: Add vim as package to be installed

### DIFF
--- a/files/preseeds/Centos.ERP.kickstart
+++ b/files/preseeds/Centos.ERP.kickstart
@@ -41,6 +41,7 @@ reboot
 chrony
 kexec-tools
 git
+vim
 
 %end
 

--- a/files/preseeds/Centos.Upstream.amd64.kickstart
+++ b/files/preseeds/Centos.Upstream.amd64.kickstart
@@ -41,6 +41,7 @@ reboot
 chrony
 kexec-tools
 git
+vim
 
 %end
 

--- a/files/preseeds/Centos.Upstream.kickstart
+++ b/files/preseeds/Centos.Upstream.kickstart
@@ -41,6 +41,7 @@ reboot
 chrony
 kexec-tools
 git
+vim
 
 %end
 

--- a/files/preseeds/Debian.amd64.preseed
+++ b/files/preseeds/Debian.amd64.preseed
@@ -90,7 +90,7 @@ d-i partman/confirm_nooverwrite boolean true
 
 # Package selection
 tasksel tasksel/first multiselect standard
-d-i pkgsel/include string openssh-server build-essential git
+d-i pkgsel/include string openssh-server build-essential git vim
 d-i pkgsel/upgrade select none
 popularity-contest popularity-contest/participate boolean false
 

--- a/files/preseeds/Debian.preseed
+++ b/files/preseeds/Debian.preseed
@@ -90,7 +90,7 @@ d-i partman/confirm_nooverwrite boolean true
 
 # Package selection
 tasksel tasksel/first multiselect standard
-d-i pkgsel/include string openssh-server build-essential git
+d-i pkgsel/include string openssh-server build-essential git vim
 d-i pkgsel/upgrade select none
 popularity-contest popularity-contest/participate boolean false
 

--- a/files/preseeds/openSUSE.Upstream.autoyast
+++ b/files/preseeds/openSUSE.Upstream.autoyast
@@ -23,6 +23,7 @@
     </patterns>
     <packages config:type="list">
       <package>perf</package>
+      <package>vim</package>
       <package>zypper-aptitude</package>
     </packages>
   </software>


### PR DESCRIPTION
Tired of installing vim every time first thing I do.
Now, to make sure that the machine is freshly installed, the fact that htop is not installed should do the trick (or emacs for that matter).